### PR TITLE
implemented remote data import from BRC data feeds

### DIFF
--- a/api/app/config/brc_schema.json
+++ b/api/app/config/brc_schema.json
@@ -1,0 +1,190 @@
+{
+    "$defs": {
+        "AnalysisType": {
+            "description": "",
+            "enum": [
+                "shotgun_proteomics",
+                "cross_linking",
+                "affinity_purification",
+                "srm_mrm",
+                "swath_ms",
+                "Ms_imaging"
+            ],
+            "title": "AnalysisType",
+            "type": "string"
+        },
+        "BRCEnum": {
+            "description": "",
+            "enum": [
+                "CABBI",
+                "CBI",
+                "GLBRC",
+                "JBEI"
+            ],
+            "title": "BRCEnum",
+            "type": "string"
+        },
+        "Dataset": {
+            "additionalProperties": false,
+            "description": "A dataset containing metabolomics and proteomics data.",
+            "properties": {
+                "analysisType": {
+                    "$ref": "#/$defs/AnalysisType",
+                    "description": "The type of analysis performed on the dataset."
+                },
+                "bibliographicCitation": {
+                    "description": "Citation for the dataset.",
+                    "type": "string"
+                },
+                "brc": {
+                    "$ref": "#/$defs/BRCEnum",
+                    "description": "Bioenergy Research Center affiliation."
+                },
+                "creator": {
+                    "description": "List of creators involved in the dataset, where one must be the primary contact.",
+                    "items": {
+                        "$ref": "#/$defs/Individual"
+                    },
+                    "type": "array"
+                },
+                "date": {
+                    "description": "The date the dataset was created or published.",
+                    "format": "date",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A detailed description of the dataset.",
+                    "type": "string"
+                },
+                "identifier": {
+                    "description": "Unique identifier for the dataset.",
+                    "type": "string"
+                },
+                "keywords": {
+                    "description": "Keywords associated with the dataset.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "relatedItem": {
+                    "$ref": "#/$defs/RelatedItem",
+                    "description": "Related publication or item."
+                },
+                "repository": {
+                    "description": "The repository where the dataset is stored.",
+                    "type": "string"
+                },
+                "species": {
+                    "description": "Species information for the organism(s) studied.",
+                    "items": {
+                        "$ref": "#/$defs/Organism"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "The title of the dataset.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "title",
+                "date",
+                "creator",
+                "brc",
+                "bibliographicCitation",
+                "identifier",
+                "species"
+            ],
+            "title": "Dataset",
+            "type": "object"
+        },
+        "DatasetCollection": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "datasets": {
+                    "items": {
+                        "$ref": "#/$defs/Dataset"
+                    },
+                    "type": "array"
+                }
+            },
+            "title": "DatasetCollection",
+            "type": "object"
+        },
+        "Individual": {
+            "additionalProperties": false,
+            "description": "An individual involved in the dataset.",
+            "properties": {
+                "affiliation": {
+                    "description": "Affiliation of the creator.",
+                    "type": "string"
+                },
+                "creatorName": {
+                    "description": "Name of the creator.",
+                    "type": "string"
+                },
+                "email": {
+                    "description": "Email address of the creator.",
+                    "type": "string"
+                },
+                "primaryContact": {
+                    "description": "Indicates if the creator is the primary contact.",
+                    "type": "boolean"
+                }
+            },
+            "title": "Individual",
+            "type": "object"
+        },
+        "Organism": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "NCBITaxID": {
+                    "description": "NCBI taxonomy ID for the organism.",
+                    "type": "integer"
+                },
+                "scientificName": {
+                    "description": "Scientific name of the organism.",
+                    "type": "string"
+                }
+            },
+            "title": "Organism",
+            "type": "object"
+        },
+        "RelatedItem": {
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+                "relatedItemIdentifier": {
+                    "description": "Identifier or URL for the related item.",
+                    "type": "string"
+                },
+                "relatedItemType": {
+                    "description": "Type of the related item, e.g., JournalArticle.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Title of the related item.",
+                    "type": "string"
+                }
+            },
+            "title": "RelatedItem",
+            "type": "object"
+        }
+    },
+    "$id": "https://w3id.org/brc/metaprot-datasets-schema",
+    "additionalProperties": true,
+    "description": "",
+    "properties": {
+        "datasets": {
+            "items": {
+                "$ref": "#/$defs/Dataset"
+            },
+            "type": "array"
+        }
+    },
+    "title": "datasets",
+    "type": "object"
+}

--- a/api/app/config/datafeeds.json
+++ b/api/app/config/datafeeds.json
@@ -1,0 +1,24 @@
+{
+    "urls": [
+        {
+            "name": "TEST",
+            "url": "https://doe.gov/random"
+        },
+        {
+            "name": "JBEI",
+            "url": null
+        },
+        {
+            "name": "CABBI",
+            "url": "https://cabbitools.igb.illinois.edu/brc/cabbi.json"
+        },
+        {
+            "name": "CBI",
+            "url": "https://fair.ornl.gov/CBI/cbi.json"
+        },
+        {
+            "name": "GLBRC",
+            "url": "https://fair-data.glbrc.org/glbrc.json"
+        }
+    ]
+}

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,10 @@
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.0"
+    "swagger-ui-express": "^5.0.0",
+    "sync-fetch": "^0.5.2",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1"

--- a/api/seed_dev_db.js
+++ b/api/seed_dev_db.js
@@ -1,24 +1,89 @@
-const { faker } = require('@faker-js/faker');
-
 require("dotenv").config( {path: ['.env','../.env'] } );
 
-// use sequelize
 const db = require("./app/models");
 const Dataset = db.datasets;
-// TODO: replace/update with migrations
-db.sequelize.sync();
 
+//db.sequelize.sync(); // This creates the table if it doesn't exist (and does nothing if it already exists).
+//db.sequelize.sync({ alter: true }); // This checks what is the current state of the table in the database (which columns it has, what are their data types, etc), and then performs the necessary changes in the table to make it match the model.
 
-// make a function to generate a random dataset
-const generateDataset = () => {
-  return {
-    title: faker.lorem.words(),
-    description: faker.lorem.sentence(),
-    published: faker.datatype.boolean(),
-  };
-};
-console.log(generateDataset());
-// perform a loop 20 times to generate 20 datasets
-for (let i = 0; i < 20; i++) {
-  Dataset.create(generateDataset());
+// Begin data import.
+
+// read a set of hard-coded URLs from a file
+const datasources = require("./app/config/datafeeds.json"); // hard-coded data feed URLs
+
+const fs = require('node:fs');
+const fetch = require('sync-fetch'); // synchronous fetch is easier for development and testing (can switch to async later if needed)
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+
+// initialize the JSON schema validator
+const ajv = new Ajv({ allErrors: 'true', verbose: 'true', strict: 'false' }); // must set option strict: false to produce specification-compliant behavior
+addFormats(ajv); // required for supporting format: date in JSON schema
+
+// load the LinkML JSON schema
+var linkml_schema_json;
+try {
+  const linkml_schema_text = fs.readFileSync('./app/config/brc_schema.json');
+  linkml_schema_json = JSON.parse(linkml_schema_text);
+} catch (err) {
+  throw err; // This is a fatal error that prevents further processing.
+}
+
+// query each URL expecting well-formed JSON matching the project schema structure
+for (const datafeed of datasources.urls) {
+
+  if (datafeed.url === null) {
+    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: missing URL)");
+    continue; // skip entire data feed
+  }
+
+  var datafeed_text;
+  try {
+    datafeed_text = fetch(datafeed.url).text();
+  } catch (err) {
+    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: retrieval failed)");
+//    console.error(err.message);
+    continue; // skip entire data feed
+  }
+
+  // expect well-formed JSON
+  var datafeed_json;
+  try {
+    datafeed_json = JSON.parse(datafeed_text);
+  } catch (err) {
+    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: malformed JSON)");
+//    console.error(err.message);
+    continue; // skip entire data feed
+  }
+  
+  // NOTE: The data feeds do not pass LinkML schema validation, so only validate at the data set level.
+
+  // process each data set in the data feed
+  for (const dataset of datafeed_json)
+  {
+    // handle malformed data gracefully (only reject individual data sets that fail validation, not entire data feeds)
+    const dataset_is_valid = ajv.validate(linkml_schema_json, dataset);
+    if (!dataset_is_valid) {
+      console.error(datafeed.name + " [" + datafeed.url + "]: DATA SET FAILED VALIDATION:", dataset);
+      console.error("ERRORS:", ajv.errors);
+      continue; // only reject data sets that fail validation
+    }
+
+    // process JSON data, importing each object into the database
+    // NOTE: In order to avoid disrupting the Dataset controller, this commit adheres to the current expectations of the controller, which are only three required fields.
+    // Therefore, when modifying this list of fields, also modify dataset.controller.js to keep the data model in sync.
+    // Eventually, we may want to rely on LinkML transformers to convert the source data to our target structure (via "linkml-runtime": "^0.2.0"?).
+
+    const dataset_is_published = !(!dataset.bibliographicCitation || dataset.bibliographicCitation.length === 0); // true/false
+
+    var processed_dataset = {
+      title: dataset.Title,
+      description: dataset.Description,
+      published: dataset_is_published
+    };
+
+//    console.log(processed_dataset);
+
+    Dataset.create(processed_dataset);
+  }
 }


### PR DESCRIPTION
## What does this do

**Progress on Issue #25**

- Deleted random data generation in seed_dev_db.js.
- Implemented the following parts of Issue 25 in seed_dev_db.js:
    - read a set of hard-coded URLs from a file (new file datafeeds.json)
    - query each URL expecting well-formed JSON matching the project schema structure
    - handle malformed data gracefully (any records that pass LinkML schema validation are imported)
    - process JSON data (see "Related Issues")
    - importing each object into the database (see "Related Issues")

**Schema Note**
The most recent [LinkML JSON schema](https://github.com/bioenergy-research-centers/brc-schema/blob/main/project/jsonschema/brc_schema.schema.json) was copied to this repo as brc_schema.json. This will need to be updated as new versions become available in that repo.

Resolved: ~~The "metamodel_version," "version," and "schema" fields were deleted from the version of the schema in this repo to avoid warnings and errors. See [issue 3](https://github.com/bioenergy-research-centers/brc-schema/issues/3) in the brc_schema repo.~~

**Package Changes**
Three Node.js package dependencies were added for the API: sync-fetch, ajv, and ajv-formats:
- Synchronous retrievals (via the sync-fetch package) of BRC data are used (for now) to facilitate development and testing. This can be switched to asynchronous requests if needed in the future.
- The ajv package is being used for validating the BRC data against the brc_schema.
- The ajv-formats package is required to support format: date in the JSON schema.

## Related Issues

**Remaining Issues Before Closure of [Issue 25](https://github.com/bioenergy-research-centers/bioenergy.org/issues/25)**
The following will be resolved by issue #42:
- update the backend app as needed to support storing json records
In order to avoid disrupting the Dataset controller, this commit adheres to the current expectations of that controller (only three fields: title, description, published) are currently processed. We can add additional fields as needed, but those changes should be done in sync between seed_dev_db.js and dataset.controller.js, and should be a separate issue.

The current database schema cannot support dataset titles greater than 255 characters. See related issue #37 (superseded by issue #42).

JBEI feed is currently rejected due to a missing URL. See related issue #38 

Resolved: ~~The CABBI feed is currently rejected due to malformed JSON. See related issue #29~~

The below question will be obviated by issue #42:
~~Open questions: Dataset.create() appears to have its own manual form of data validation. Do we need a separate JSON schema to validate datasets, or is the brc_schema intended to be the target that our DB and the BRCs conform to (or are we supposed to use LinkML to transform from the BRC schema to a "dataset" schema)?~~

## Acceptance

- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)

### Testing Locally

I made some minor adjustments to get my database container running in my development environment.

My local .env file is as follows:
```
# API Configuration
BIOENERGY_ORG_API_LOCAL_PORT=8080
VITE_BIOENERGY_ORG_API_URI=http://localhost:8080
# VITE_BIOENERGY_ORG_API_URI=http://api.bioenergy.org # for Production

# Client Configuration
BIOENERGY_ORG_CLIENT_LOCAL_PORT=3000

# Database Configuration
# for docker to connect to host machine running postgres, use host.docker.internal
BIOENERGY_ORG_DB_HOST=host.docker.internal
BIOENERGY_ORG_DB_LOCAL_PORT=6432
BIOENERGY_ORG_DB_USER=postgres
BIOENERGY_ORG_DB_PASSWORD=mysecretpassword
BIOENERGY_ORG_DB_NAME=postgres
```

My local docker-compose.yml is as follows:
```
version: "3.8"

services:
  api:
    build: ./api
    restart: unless-stopped
    env_file:
      - .env
    ports:
      - ${BIOENERGY_ORG_API_LOCAL_PORT}:8080
    stdin_open: true
    tty: true
    volumes:
      - ./api:/api
  client:
    depends_on:
      - api
    build:
      context: ./client
      dockerfile: Dockerfile.dev
    ports:
      - ${BIOENERGY_ORG_CLIENT_LOCAL_PORT}:3000
    environment:
      - BIOENERGY_ORG_CLIENT_LOCAL_PORT
    volumes:
      - ./client:/app
      - /app/node_modules/
    restart: unless-stopped
    env_file:
      - .env
    stdin_open: true
    tty: true
```

Then run the following commands:
```
docker run --name postgres -e POSTGRES_PASSWORD=mysecretpassword -d -p 6432:5432 postgres
docker-compose up --build
docker compose run api node seed_dev_db.js
```
