### PR TITLE
add user mentions to feedback messages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,3 +40,6 @@ TURNSTILE_SECRETKEY=1x0000000000000000000000000000000AA     # test key - always 
 #TURNSTILE_SECRETKEY=2x0000000000000000000000000000000AA    # test key - always fails
 #VITE_TURNSTILE_SITEKEY=PROD_CHANGEME                       # production key - displayed publicly in client
 #TURNSTILE_SECRETKEY=PROD_SECRET_CHANGEME                   # production key
+
+# Footer text to mention/notify users of new messages
+MESSAGE_MENTION_STRING="@brc-bot"                           # Replace with github user mentions

--- a/api/app/controllers/message.controller.js
+++ b/api/app/controllers/message.controller.js
@@ -2,6 +2,7 @@ const {validateTurnstileForm} = require('../utils/turnstileValidator');
 const {formatContactForm} = require('../utils/markdownFormatter');
 const {syncIssueComment} = require("../services/githubService");
 const sanitizeHtml = require('sanitize-html');
+const messageMention = process.env.MESSAGE_MENTION_STRING;
 
 // Create new Message
 async function create(req, res) {
@@ -20,7 +21,10 @@ async function create(req, res) {
     // Create or update new message
     // Title and label are used to find existing comments
     const title = `${sanitizeHtml(data.contact_name)} (${sanitizeHtml(data.contact_email)}) - ${data.contact_reason}`;
-    const formattedMessage = formatContactForm(data);
+    const formattedMessage = formatContactForm(data) + `---\n\n${messageMention}\n
+    Assign to the person that will respond in email.
+    Comments are private to BRC organization members and can be used for discussion.
+    Close this issue when the request is addressed.`;
     const saveStatus = syncIssueComment(title, formattedMessage, {labels: 'contact-form'}); 
     
     if(saveStatus){


### PR DESCRIPTION
## What does this do
Adds a new ENV config `MESSAGE_MENTION_STRING` to configure user notifications on new messages.

## Related Issues

No Issue, request from tech team meeting on 2/27.

## Screenshots
<img width="909" alt="Screenshot 2025-03-06 at 11 54 31 AM" src="https://github.com/user-attachments/assets/8f42b35d-06cb-4a33-be95-fbbce1f29150" />



## Acceptance

Add an 'x' to the boxes below if they are complete
- [ ] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
