### PR TITLE
fix missing octokit package and prod env variable

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,10 +3,10 @@ FROM node:20
 RUN apt-get update && apt-get install -y cron
 RUN ["mkdir", "/install"]
 WORKDIR /install
-ENV NODE_PATH=/install/node_modules
 COPY package*.json .
 RUN npm install
 
 WORKDIR /api
 COPY . .
+RUN cp -r /install/node_modules /api/node_modules
 CMD npm start

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -3,10 +3,10 @@ FROM node:20
 RUN apt-get update && apt-get install -y cron
 RUN ["mkdir", "/install"]
 WORKDIR /install
-ENV NODE_PATH=/install/node_modules
 COPY package*.json .
 RUN npm install
 
 WORKDIR /api
 COPY . .
+RUN cp -r /install/node_modules /api/node_modules
 CMD npx nodemon

--- a/api/app/controllers/message.controller.js
+++ b/api/app/controllers/message.controller.js
@@ -10,7 +10,7 @@ async function create(req, res) {
     // Validate CF turnstile key
     const cfValid = await validateTurnstileForm(req);
     if(!cfValid){
-      res.json({error: "Invalid form data. Please verify you human."});
+      res.json({error: "Invalid form data. Please verify you are human."});
       return;
     }
     if(!data.contact_name || !data.contact_email || !data.contact_reason || !data.contact_comment){
@@ -21,7 +21,7 @@ async function create(req, res) {
     // Title and label are used to find existing comments
     const title = `${sanitizeHtml(data.contact_name)} (${sanitizeHtml(data.contact_email)}) - ${data.contact_reason}`;
     const formattedMessage = formatContactForm(data);
-    const saveStatus = syncIssueComment(title, formattedMessage, {labels: 'contact-form'}); 
+    const saveStatus = await syncIssueComment(title, formattedMessage, {labels: 'contact-form'}); 
     
     if(saveStatus){
       res.json({success: true, message: 'Message saved.'});

--- a/api/app/services/githubService.js
+++ b/api/app/services/githubService.js
@@ -14,7 +14,10 @@ async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='
     const octokit = new Octokit({ auth: process.env.GITHUB_INBOX_REPO_TOKEN });
     const serviceEnabled = process.env.GITHUB_SERVICE_ENABLED==='true';
     const serviceWriteEnabled = process.env.GITHUB_SERVICE_WRITE_ENABLED==='true';
-    if(!serviceEnabled) { return; }
+    if(!serviceEnabled) {
+      console.log(`Github Service not enabled. Skipping new issue for: ${title}`);
+      return false;
+    }
 
     // Fetch all open issues matching supplied labels and state
     const issues = await octokit.paginate(
@@ -73,7 +76,7 @@ async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='
           return true;
         } else {
           console.log(`Write disabled. Skipping issue comment for: ${title}`);
-          return true;
+          return false;
         }
         
       }
@@ -91,7 +94,7 @@ async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='
         return true;
       } else {
         console.log(`Write disabled. Skipping new issue for: ${title}`);
-        return true;
+        return false;
       }
     }
   } catch (error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       context: ./client
       args:
         VITE_BIOENERGY_ORG_API_URI: ${VITE_BIOENERGY_ORG_API_URI}
+        VITE_TURNSTILE_SITEKEY: ${VITE_TURNSTILE_SITEKEY}
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
## What does this do
Fixes a bug in the feedback form.
- adds missing turnstile ENV to prod image args
- moves node_modules to api folder. Using `import` to dynamically import the `@octokit/rest` package did not work with the ENV: `NODE_PATH`. 
- Fixes error alert messages.

## Related Issues

Fixes #101 


## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
