### PR TITLE
Fix placeholder text in search input

### DIFF
--- a/client/src/views/HeaderView.vue
+++ b/client/src/views/HeaderView.vue
@@ -53,7 +53,7 @@ const clearSequence = () => {
           <form @submit.prevent="onSubmit" class="flex-grow-1">
             <div class="input-group">
               <!-- Main Search Input -->
-              <input class="form-control" placeholder="Search bioenergy.gov" v-model="searchText"/>
+              <input class="form-control" placeholder="Search bioenergy.org" v-model="searchText"/>
               <button type="submit" class="btn btn-sm btn-outline-secondary">
                 <i class="bi bi-search text-muted"></i>
               </button>


### PR DESCRIPTION
## What does this do
Changes mention of "bioenergy.gov" in header search input placeholder to "bioenergy.org"

## Related Issues

Fixes #105 

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
