### PR TITLE
restrict minor version updates on pinia-plugin-persistedstate package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.4.5",
     "jquery": "^3.7.1",
     "pinia": "^2.2.4",
-    "pinia-plugin-persistedstate": "^4.1.2",
+    "pinia-plugin-persistedstate": "4.2.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"
   },


### PR DESCRIPTION
## What does this do
Applies a specific version to the client package: `pinia-plugin-persistedstate`

This package has a new version `4.3.0` released May 11th, 2025 with breaking changes that require pinia major version `3`
- https://github.com/prazdevs/pinia-plugin-persistedstate/releases/tag/v4.3.0 

Restricting this package to `4.2.0` avoids conflicts with npm resolving the pinia package version, currently set as: `^2.2.4` 

## Related Issues

Fixes #119 

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
