### PR TITLE
add plasmid table and reusable organism link component

### DIFF
--- a/client/src/components/OrganismLink.vue
+++ b/client/src/components/OrganismLink.vue
@@ -1,0 +1,19 @@
+<script setup>
+  const props = defineProps(['organism']);
+</script>
+
+<template>
+  <div v-if="organism">
+    <div v-if="organism.scientificName && organism.NCBITaxID">
+      <a :href="'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=' + organism.NCBITaxID" target="_blank" rel="noopener noreferrer">
+        <nobr>
+          {{ organism.scientificName }}
+          <i class="bi bi-box-arrow-up-right"></i>
+        </nobr>
+      </a>
+    </div>
+    <div v-else-if="organism.scientificName">
+      {{ organism.scientificName}}
+    </div>
+  </div>
+</template>

--- a/client/src/views/datasets/Dataset_0_1_0.vue
+++ b/client/src/views/datasets/Dataset_0_1_0.vue
@@ -1,5 +1,6 @@
 <script setup>
   import { computed } from 'vue';
+  import OrganismLink from '@/components/OrganismLink.vue';
   const props = defineProps(['selectedResult']);
   const primaryCreators = computed(() => {
     const creators = props.selectedResult?.creator
@@ -56,16 +57,41 @@
           {{ Array.from(selectedResult.keywords).join(', ') }}
         </div>
 
-        <div v-if="selectedResult.species" class="mt-4">
+        <div v-if="selectedResult.species && selectedResult.species.length" class="mt-4">
           <div class="small text-uppercase mt-5 fw-bold">Species</div>
           <div class="d-flex justify-content-start">
             <div v-for="species in selectedResult.species" :key="species.NCBITaxID">
               <div class="me-5">
-                <b class="fs-7 text-uppercase text-muted">Scientific Name: </b>{{ species.scientificName }}<br>
-                <b class="fs-7 text-uppercase text-muted">NCBITaxID: </b>{{ species.NCBITaxID }}
+                <OrganismLink :organism="species"/>
               </div>
             </div>
           </div>
+        </div>
+
+        <div v-if="selectedResult.plasmid_features && selectedResult.plasmid_features.length" class="mt-4">
+          <div class="small text-uppercase mt-5 fw-bold">Plasmid Features</div>
+          <table class="table table-light">
+            <thead>
+              <tr>
+                <th scope="col">Backbone</th>
+                <th scope="col">Selection Marker</th>
+                <th scope="col">Promoters</th>
+                <th scope="col">Origin of Replication</th>
+                <th scope="col">Replicates In</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="plasmid in selectedResult.plasmid_features">
+                <td>{{ plasmid.backbone }}</td>
+                <td>{{ Array.from(plasmid.selection_markers).join(', ') }}</td>
+                <td>{{ Array.from(plasmid.promoters).join(', ') }}</td>
+                <td>{{ plasmid.ori }}</td>
+                <td>
+                  <OrganismLink :organism="plasmid.replicates_in"/>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
 
         <div v-if="selectedResult.relatedItem" class="mt-4">


### PR DESCRIPTION
## What does this do
- Adds a new table rendering all `plasmid_features` for a dataset.
- Adds a new reusable `OrganismLink` component to render species names linked to NCBITaxID.
  - Used for organism links in new table and `species` attributes

## Related Issues

Fixes #121 

## Screenshots

New plasmid table with manually added `replicates_in` value to showing OrganismLink:
- <img width="1376" alt="Screenshot 2025-05-16 at 3 19 26 PM" src="https://github.com/user-attachments/assets/f8cfc80c-1732-4d8d-93e9-92a71c45467b" />

Updated Species attribute reusing new link component:
- <img width="1388" alt="Screenshot 2025-05-16 at 3 08 02 PM" src="https://github.com/user-attachments/assets/27e031a8-dde7-496e-9093-aceb207a78d0" />


## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
