### PR TITLE
fix duplicate dataset validation comments

### DIFF
--- a/api/app/services/githubService.js
+++ b/api/app/services/githubService.js
@@ -4,7 +4,7 @@
 // If neither match, creates a new comment with new 'formattedBody'.
 
 async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='sync', maxIssueLimit=200, maxCommentLimit=100} = {}) {
-  let title = rawTitle.substring(0,256);
+  const title = rawTitle.substring(0,256);
   // Search expects single comma separated label string, while create expects array of labels, so we need both.
   labels_arr = labels.split(",").map(item => item.trim());
   console.log("checking issue:", title, state, labels, labels_arr);

--- a/api/app/services/githubService.js
+++ b/api/app/services/githubService.js
@@ -6,7 +6,7 @@
 async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='sync', maxIssueLimit=200, maxCommentLimit=100} = {}) {
   const title = rawTitle.substring(0,256);
   // Search expects single comma separated label string, while create expects array of labels, so we need both.
-  labels_arr = labels.split(",").map(item => item.trim());
+  const labels_arr = labels.split(",").map(item => item.trim());
   console.log("checking issue:", title, state, labels, labels_arr);
   try {  
     // dynamic import of ES module inside commonJS

--- a/api/app/services/githubService.js
+++ b/api/app/services/githubService.js
@@ -4,7 +4,7 @@
 // If neither match, creates a new comment with new 'formattedBody'.
 
 async function syncIssueComment(rawTitle, formattedBody, {state="open", labels='sync', maxIssueLimit=200, maxCommentLimit=100} = {}) {
-  title = rawTitle.substring(0,256);
+  let title = rawTitle.substring(0,256);
   // Search expects single comma separated label string, while create expects array of labels, so we need both.
   labels_arr = labels.split(",").map(item => item.trim());
   console.log("checking issue:", title, state, labels, labels_arr);


### PR DESCRIPTION
## What does this do
Fixes inconsistent assignment of validation comments from dataset import. The `title` variable in `githubService` was mistakenly defined as a global variable, causing different feeds to post comments on the same issue.

## Related Issues

None, bug fix for prod error.

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [ ] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
