### PR TITLE
Added support for schema 0.1.3.

### DIFF
--- a/api/app/schemas/brc_schema_0.1.3.json
+++ b/api/app/schemas/brc_schema_0.1.3.json
@@ -1,0 +1,682 @@
+{
+    "$defs": {
+        "AnalysisType": {
+            "description": "Type of analysis performed on the dataset.",
+            "enum": [
+                "affinity_purification",
+                "cross_linking",
+                "Expression profiling",
+                "Genomic - SNP calling",
+                "image_analysis",
+                "Ms_imaging",
+                "shotgun_proteomics",
+                "srm_mrm",
+                "swath_ms",
+                "Targeted Locus (Loci)"
+            ],
+            "title": "AnalysisType",
+            "type": "string"
+        },
+        "BRCEnum": {
+            "description": "Bioenergy Research Center affiliation.",
+            "enum": [
+                "CABBI",
+                "CBI",
+                "GLBRC",
+                "JBEI"
+            ],
+            "title": "BRCEnum",
+            "type": "string"
+        },
+        "CitedItemType": {
+            "description": "Type of cited item, e.g., journal article.",
+            "enum": [
+                "JournalArticle",
+                "Book",
+                "Dataset",
+                "Software",
+                "Thesis",
+                "Patent",
+                "Preprint",
+                "Presentation",
+                "Report",
+                "Webpage",
+                "WebApplication"
+            ],
+            "title": "CitedItemType",
+            "type": "string"
+        },
+        "Contributor": {
+            "additionalProperties": false,
+            "description": "An individual who contributed to the dataset in some manner, not necessarily as an author.",
+            "properties": {
+                "affiliation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Organization"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Affiliation of the individual.",
+                    "type": "string"
+                },
+                "contributorType": {
+                    "$ref": "#/$defs/ContributorTypeCodes",
+                    "description": "The contribution type."
+                },
+                "email": {
+                    "description": "Email address of the individual.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "Name of the individual.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "orcid": {
+                    "description": "ORCID for the individual. This should include the full URI with prefix, e.g., https://orcid.org/0000-0002-1825-0097.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "primaryContact": {
+                    "description": "Indicates if the individual is a primary contact.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Contributor",
+            "type": "object"
+        },
+        "ContributorTypeCodes": {
+            "description": "The type of contribution. These values are based on the OSTI schema (ELINK 241.6).",
+            "enum": [
+                "ContactPerson",
+                "DataCollector",
+                "DataCurator",
+                "DataManager",
+                "Distributor",
+                "Editor",
+                "HostingInstitution",
+                "Producer",
+                "ProjectLeader",
+                "ProjectManager",
+                "ProjectMember",
+                "RegistrationAgency",
+                "RegistrationAuthority",
+                "RelatedPerson",
+                "Researcher",
+                "ResearchGroup",
+                "RightsHolder",
+                "Sponsor",
+                "Supervisor",
+                "WorkPackageLeader",
+                "Other"
+            ],
+            "title": "ContributorTypeCodes",
+            "type": "string"
+        },
+        "Dataset": {
+            "additionalProperties": false,
+            "description": "A body of structured information describing some topic or topics of interest. This includes metadata about the dataset.",
+            "properties": {
+                "active": {
+                    "description": "Indicates whether the dataset is active or inactive. This is a boolean field - true indicates active, false indicates inactive.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "additional_brcs": {
+                    "description": "Additional Bioenergy Research Center affiliations. This is a list of one or more additional BRC names, for instances in which the dataset is associated with multiple centers.",
+                    "items": {
+                        "$ref": "#/$defs/BRCEnum"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "alert": {
+                    "description": "Indicates whether availability of the dataset has encountered some inconsistency. This is a boolean field - true indicates alert, false indicates no alert. For example, if we have a Dataset object but the Dataset is missing from its source feed, this should be set to true.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "analysisType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AnalysisType"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of analysis performed on the dataset.",
+                    "type": "string"
+                },
+                "bibliographicCitation": {
+                    "description": "Citation for the dataset.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "brc": {
+                    "$ref": "#/$defs/BRCEnum",
+                    "description": "The primary Bioenergy Research Center affiliation. This is a single BRC name."
+                },
+                "contributors": {
+                    "description": "Contributors to the dataset who are not necessarily authors.",
+                    "items": {
+                        "$ref": "#/$defs/Contributor"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "creator": {
+                    "description": "List of creators involved in the dataset, where one must be the primary contact.",
+                    "items": {
+                        "$ref": "#/$defs/Individual"
+                    },
+                    "type": "array"
+                },
+                "datasetName": {
+                    "description": "\"Name of a overall dataset to which this data entry belongs.\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "datasetType": {
+                    "$ref": "#/$defs/DatasetTypeCodes",
+                    "description": "High-level type of the main content of the dataset."
+                },
+                "dataset_url": {
+                    "description": "URL for the dataset landing page.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "date": {
+                    "description": "The date the dataset was created or published.",
+                    "format": "date",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A detailed description of the dataset.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "funding": {
+                    "description": "Funding source(s) for the dataset.",
+                    "items": {
+                        "$ref": "#/$defs/Funding"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "has_related_ids": {
+                    "description": "\"Related identifiers for the dataset. These should be identifiers to records in other repositories, and these records may be the same data or components of the dataset.\"",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "id": {
+                    "description": "Unique identifier for the dataset, assigned prior to inclusion in bioenergy.org.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique identifier for the dataset.",
+                    "type": "string"
+                },
+                "keywords": {
+                    "description": "Keywords associated with the dataset.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "plasmid_features": {
+                    "description": "Description of plasmid features, if applicable. This is a multivalued field.",
+                    "items": {
+                        "$ref": "#/$defs/Plasmid"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "relatedItem": {
+                    "description": "Related publications or items.",
+                    "items": {
+                        "$ref": "#/$defs/RelatedItem"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "repository": {
+                    "$ref": "#/$defs/RepositoryEnum",
+                    "description": "The repository where the dataset is stored."
+                },
+                "species": {
+                    "description": "Species information for the organism(s) studied.",
+                    "items": {
+                        "$ref": "#/$defs/Organism"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "title": {
+                    "description": "The title of the dataset.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "title",
+                "date",
+                "creator",
+                "brc",
+                "identifier"
+            ],
+            "title": "Dataset",
+            "type": "object"
+        },
+        "DatasetCollection": {
+            "additionalProperties": false,
+            "description": "Container class for defining a collection of datasets.",
+            "properties": {
+                "datasets": {
+                    "description": "List of datasets in the collection.",
+                    "items": {
+                        "$ref": "#/$defs/Dataset"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "schema_version": {
+                    "description": "Version of the schema used for the collection.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "DatasetCollection",
+            "type": "object"
+        },
+        "DatasetTypeCodes": {
+            "description": "High-level type of the main content of the dataset, following OSTI categories. See https://www.osti.gov/elink/F2416instruct.jsp",
+            "enum": [
+                "AS",
+                "GD",
+                "IM",
+                "ND",
+                "IP",
+                "FP",
+                "SM",
+                "MM",
+                "I"
+            ],
+            "title": "DatasetTypeCodes",
+            "type": "string"
+        },
+        "Funding": {
+            "additionalProperties": false,
+            "description": "Funding source for the dataset. Each item corresponds to a single award or grant.",
+            "properties": {
+                "awardNumber": {
+                    "description": "Award number from the funding entity.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "awardTitle": {
+                    "description": "Title of the award.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "awardURI": {
+                    "description": "URI for the award. This may be a DOI. Include prefix.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "fundingOrganization": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Organization"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Details of the funding entity."
+                }
+            },
+            "title": "Funding",
+            "type": "object"
+        },
+        "Individual": {
+            "additionalProperties": false,
+            "description": "An individual involved in the dataset.",
+            "properties": {
+                "affiliation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Organization"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Affiliation of the individual.",
+                    "type": "string"
+                },
+                "email": {
+                    "description": "Email address of the individual.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "description": "Name of the individual.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "orcid": {
+                    "description": "ORCID for the individual. This should include the full URI with prefix, e.g., https://orcid.org/0000-0002-1825-0097.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "primaryContact": {
+                    "description": "Indicates if the individual is a primary contact.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Individual",
+            "type": "object"
+        },
+        "Organism": {
+            "additionalProperties": false,
+            "description": "An organism studied in the dataset.",
+            "properties": {
+                "NCBITaxID": {
+                    "description": "NCBI taxonomy ID for the organism.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "scientificName": {
+                    "description": "Scientific name of the organism.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Organism",
+            "type": "object"
+        },
+        "Organization": {
+            "additionalProperties": false,
+            "description": "An organization involved in the dataset.",
+            "properties": {
+                "organizationName": {
+                    "description": "Name of the organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "parentOrganization": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Organization"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Higher-level parent of this organization."
+                },
+                "ror_id": {
+                    "description": "ROR identifier for the organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "wikidata_id": {
+                    "description": "Wikidata identifier for the organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Organization",
+            "type": "object"
+        },
+        "Plasmid": {
+            "additionalProperties": false,
+            "description": "Description of plasmid or other molecular vector features.",
+            "properties": {
+                "backbone": {
+                    "description": "Name of the backbone of the plasmid, e.g., pUC19.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "description": "Description of the plasmid, including any relevant features not captured in other fields.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "host": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Organism"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Host organism for the plasmid, e.g., E. coli. Includes both the scientific name and NCBI Taxonomy ID."
+                },
+                "id": {
+                    "description": "Unique identifier for the plasmid. This must be unique within the dataset.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ori": {
+                    "description": "Origin of replication for the plasmid, e.g., ColE1.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "promoters": {
+                    "description": "Promoters for the plasmid, e.g., T7.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "replicates_in": {
+                    "description": "Organism(s) in which the plasmid replicates. Includes both the scientific name and NCBI Taxonomy ID.",
+                    "items": {
+                        "$ref": "#/$defs/Organism"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "selection_markers": {
+                    "description": "Selection markers for the plasmid, e.g, kan.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Plasmid",
+            "type": "object"
+        },
+        "RelatedItem": {
+            "additionalProperties": false,
+            "description": "A related publication or item, including cited publications.",
+            "properties": {
+                "relatedItemIdentifier": {
+                    "description": "Identifier or URL for the related item.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "relatedItemType": {
+                    "$ref": "#/$defs/CitedItemType",
+                    "description": "Type of the related item, e.g., JournalArticle."
+                },
+                "title": {
+                    "description": "Title of the related item.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "RelatedItem",
+            "type": "object"
+        },
+        "RepositoryEnum": {
+            "description": "Repository where the dataset is stored.",
+            "enum": [
+                "AmeriFlux",
+                "Bio-Protocol",
+                "Dryad",
+                "FigShare",
+                "GenBank",
+                "GEO",
+                "GitHub",
+                "GLBRC Sustainability",
+                "Iowa State University FigShare",
+                "ICE",
+                "Illinois Data Bank",
+                "iProX",
+                "JGI Gold",
+                "jPOST",
+                "MassIVE",
+                "Mendeley Data",
+                "National Microbiome Data Collaborative",
+                "NCBI BioProject",
+                "NCBI SRA",
+                "ORNL DAAC",
+                "OSTI",
+                "PanoramaPublic",
+                "PedtideAtlas",
+                "PRIDE",
+                "Protein Data Bank",
+                "The Cambridge Crystallographic Data Centre",
+                "Zenodo"
+            ],
+            "title": "RepositoryEnum",
+            "type": "string"
+        }
+    },
+    "$id": "https://w3id.org/brc/brc_schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": true,
+    "description": "Container class for defining a collection of datasets.",
+    "metamodel_version": "1.7.0",
+    "properties": {
+        "datasets": {
+            "description": "List of datasets in the collection.",
+            "items": {
+                "$ref": "#/$defs/Dataset"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "schema_version": {
+            "description": "Version of the schema used for the collection.",
+            "type": [
+                "string",
+                "null"
+            ]
+        }
+    },
+    "title": "brc_schema",
+    "type": "object",
+    "version": "0.1.3"
+}

--- a/api/app/schemas/schema_list.json
+++ b/api/app/schemas/schema_list.json
@@ -14,4 +14,8 @@
     "version": "0.1.2",
     "filename": "brc_schema_0.1.2.json",
     "supported": true
+},{
+    "version": "0.1.3",
+    "filename": "brc_schema_0.1.3.json",
+    "supported": true
 }]


### PR DESCRIPTION
## What does this do

Adds data ingest support for data feeds conforming to schema v0.1.3.

## Related Issues

Fixes #141

## Screenshots

For reference, the data feed import results are identical when validating the current data feeds against their matching versions and against version 0.1.3. So, unless schema v0.1.3 requires UI changes, all feeds can bump their version numbers up to 0.1.3. JBEI and GLBRC feeds still need to fix their two records that fail validation.

- JBEI feed (v0.1.2): 2 errors (relatedItem must be an array or null, not a singleton)
- CABBI feed (v0.1.1): 0 errors
- CBI feed (v0.1.0): 0 errors
- GLBRC feed (v0.1.0): 2 errors ("BioProject" should be "NCBI BioProject", and schema support needs to be added for "JGI Genome Portal" - even though the Genome Portal will be decommissioned, the URLs will forward to the new Data Portal, see Issue #138)

Data Import Summary: {
  'https://bioenergy.org/JBEI/jbei.json': { valid: 269, invalid: 2 },
  'https://cabbitools.igb.illinois.edu/brc/cabbi.json': { valid: 112, invalid: 0 },
  'https://fair.ornl.gov/CBI/cbi.json': { valid: 2, invalid: 0 },
  'https://fair-data.glbrc.org/glbrc.json': { valid: 53, invalid: 2 }
}

```
Validating JBEI against brc_schema_0.1.2.json

[https://bioenergy.org/JBEI/jbei.json]: DATA SET 259 FAILED VALIDATION - identifier: PXD020215
[
  {
    msg: '/datasets/0/relatedItem: must be array,null',
    provided: {
      title: 'A multiplexed nanostructure-initiator mass spectrometry (NIMS) assay for simultaneously detecting glycosyl hydrolase and lignin modifying enzyme activities',
      relatedItemType: 'JournalArticle',
      relatedItemIdentifier: 'https://www.nature.com/articles/s41598-021-91181-8'
    },
    required: [ 'array', 'null' ]
  }
]

[https://bioenergy.org/JBEI/jbei.json]: DATA SET 261 FAILED VALIDATION - identifier: PXD013623
[
  {
    msg: '/datasets/0/relatedItem: must be array,null',
    provided: {
      title: 'Systems Analysis of NADH Dehydrogenase Mutants Reveals Flexibility and Limits of Pseudomonas taiwanensis VLB120’s Metabolism',
      relatedItemType: 'JournalArticle',
      relatedItemIdentifier: 'https://journals.asm.org/doi/10.1128/aem.03038-19'
    },
    required: [ 'array', 'null' ]
  }
]

Validating GLBRC against brc_schema_0.1.0.json

[https://fair-data.glbrc.org/glbrc.json]: DATA SET 25 FAILED VALIDATION - identifier: 1390741
[
  {
    msg: '/datasets/0/repository: must be equal to one of the allowed values',
    provided: 'JGI Genome Portal',
    required: [
      'AmeriFlux',
      'Bio-Protocol',
      'Dryad',
      'FigShare',
      'GenBank',
      'GEO',
      'GitHub',
      'GLBRC Sustainability',
      'Iowa State University FigShare',
      'ICE',
      'Illinois Data Bank',
      'iProX',
      'JGI Gold',
      'jPOST',
      'MassIVE',
      'Mendeley Data',
      'NCBI BioProject',
      'NCBI SRA',
      'ORNL DAAC',
      'OSTI',
      'PanoramaPublic',
      'PedtideAtlas',
      'PRIDE',
      'Protein Data Bank',
      'The Cambridge Crystallographic Data Centre',
      'Zenodo'
    ]
  }
]

[https://fair-data.glbrc.org/glbrc.json]: DATA SET 52 FAILED VALIDATION - identifier: PRJNA1228652
[
  {
    msg: '/datasets/0/repository: must be equal to one of the allowed values',
    provided: 'BioProject',
    required: [
      'AmeriFlux',
      'Bio-Protocol',
      'Dryad',
      'FigShare',
      'GenBank',
      'GEO',
      'GitHub',
      'GLBRC Sustainability',
      'Iowa State University FigShare',
      'ICE',
      'Illinois Data Bank',
      'iProX',
      'JGI Gold',
      'jPOST',
      'MassIVE',
      'Mendeley Data',
      'NCBI BioProject',
      'NCBI SRA',
      'ORNL DAAC',
      'OSTI',
      'PanoramaPublic',
      'PedtideAtlas',
      'PRIDE',
      'Protein Data Bank',
      'The Cambridge Crystallographic Data Centre',
      'Zenodo'
    ]
  }
]
```

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [-] I updated the Changelog (if applicable)
- [-] I added tests with appropriate coverage and verified they all pass (if applicable)
- [-] I updated user documentation (if applicable)
