### PR TITLE
Support html tags in dataset title

### DIFF
--- a/api/app/models/dataset.model.js
+++ b/api/app/models/dataset.model.js
@@ -1,4 +1,6 @@
 const { Model, DataTypes } = require("sequelize");
+const sanitizeHtml = require('sanitize-html');
+const ALLOWED_HTML = { allowedTags: [ 'b', 'i', 'sub', 'sup'], allowedAttributes: {} };
 
 module.exports = (sequelize, Sequelize) => {
   class Dataset extends Model {
@@ -24,7 +26,14 @@ module.exports = (sequelize, Sequelize) => {
       },
       json: {
         type: DataTypes.JSONB,
-        allowNull: false
+        allowNull: false,
+        set(rawJSON) {
+          // sanitize all string values
+          const cleanJSON = JSON.parse(JSON.stringify(rawJSON,
+            (_key, value) => (typeof value === "string" ? sanitizeHtml(value, ALLOWED_HTML) : value)
+          ));
+          this.setDataValue('json', cleanJSON);
+        }
       }
     },
     { 

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,8 @@
     "pinia": "^2.2.4",
     "pinia-plugin-persistedstate": "4.2.0",
     "vue": "^3.4.15",
-    "vue-router": "^4.2.5"
+    "vue-router": "^4.2.5",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.3.3",

--- a/client/src/views/SearchResults.vue
+++ b/client/src/views/SearchResults.vue
@@ -3,6 +3,9 @@ import DatasetDataService from "../services/DatasetDataService";
 import {ref, watch} from "vue";
 import { resolveComponentVersion } from './datasets/versionComponentMap';
 
+import sanitizeHtml from 'sanitize-html';
+const ALLOWED_HTML = { allowedTags: [ 'b', 'i', 'sub', 'sup'], allowedAttributes: {} };
+
 const results = ref([]);
 const loading = ref(true);
 const error = ref(null);
@@ -75,6 +78,12 @@ watch(
 const onSelectResult = (result: any) => {
   selectedResult.value = result;
 }
+
+const truncateMiddle = (str, maxStart = 100, maxEnd = 50) => {
+  if (str.length <= maxStart + maxEnd) return str;
+  return str.slice(0, maxStart) + "…" + str.slice(-maxEnd);
+}
+
 </script>
 
 <template>
@@ -106,11 +115,11 @@ const onSelectResult = (result: any) => {
               :class="{ active: selectedResult.identifier === result.identifier }"
               @click="onSelectResult(result)"
           >
-            <div class="ms-2 me-auto">
-              <div class="mb-2 fw-bold">{{ result.identifier }}</div>
-              <div class="small">{{ result.title }}</div>
+            <div class="list-group-item-content ms-2 me-auto">
+              <div class="mb-2 fw-bold">{{ truncateMiddle(result.identifier, 25,25) }}</div>
+              <div class="small" v-html="sanitizeHtml(truncateMiddle(result.title), ALLOWED_HTML)"></div>
             </div>
-            <small style="font-size: 0.75em">{{ result.date }}</small>
+            <small class="ps-1" style="font-size: 0.75em">{{ result.date }}</small>
           </div>
         </div>
       </div>
@@ -125,6 +134,11 @@ const onSelectResult = (result: any) => {
 
 
 <style scoped>
+.list-group-item-content {
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
 .page-container {
   display: flex;
   height: 100vh;

--- a/client/src/views/datasets/Dataset_0_1_0.vue
+++ b/client/src/views/datasets/Dataset_0_1_0.vue
@@ -1,6 +1,9 @@
 <script setup>
   import { ref, computed } from 'vue';
   import OrganismLink from '@/components/OrganismLink.vue';
+  import sanitizeHtml from 'sanitize-html';
+  const ALLOWED_HTML = { allowedTags: [ 'b', 'i', 'sub', 'sup'], allowedAttributes: {} };
+
   const props = defineProps(['selectedResult']);
   const expandedIndex=ref(null);
   function toggleDesc(idx) {
@@ -12,10 +15,11 @@
     if(!Array.isArray(creators)) { return []; }
     return creators.filter(item => item.primaryContact === true);
   });
+  
 </script>
 
 <template>
-  <h3>{{ selectedResult.title }}</h3>
+  <h3 v-html="sanitizeHtml(selectedResult?.title, ALLOWED_HTML)"></h3>
         <div>
           More information at:
           <a :href="selectedResult.bibliographicCitation" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">
@@ -54,7 +58,7 @@
 
         <div v-if="selectedResult.description" class="mt-4">
           <div class="small text-uppercase mt-5 fw-bold">Description</div>
-          {{ selectedResult.description }}
+          <span v-html="sanitizeHtml(selectedResult?.description, ALLOWED_HTML)"></span>
         </div>
 
         <div v-if="selectedResult.keywords && selectedResult.keywords.length" class="mt-4">


### PR DESCRIPTION
## What does this do

Add support for specific html tags to render in dataset titles and descriptions.
- Uses https://github.com/apostrophecms/sanitize-html to remove unsupported tags from dataset records during import.
- Allowed tags: `b`, `i`, `sub`, `sup`

Also adds a truncate method and style changes to avoid text overflow in the dataset listing.


## Related Issues

Fixes #80

## Screenshots

### Before
<img width="3198" height="1720" alt="Screenshot 2025-08-28 at 4 46 52 PM" src="https://github.com/user-attachments/assets/8517a183-f354-4169-ab05-ba51f13aaffb" />

### After
<img width="3238" height="1756" alt="Screenshot 2025-08-28 at 5 58 27 PM" src="https://github.com/user-attachments/assets/3f06baef-8842-4f08-836d-695c73d1c3cd" />


## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
