### PR TITLE
add synchronous await on each record upsert

### DIFF
--- a/api/scripts/import_datafeeds.js
+++ b/api/scripts/import_datafeeds.js
@@ -16,123 +16,139 @@ const fetch = require('sync-fetch'); // synchronous fetch is easier for developm
 const Ajv = require('ajv/dist/2019'); // this specific path is required to support the BRC schemas (rather than simply 'ajv');
 const addFormats = require('ajv-formats');
 
-const feed_summary = {};
-const invalid_feeds = {};
-
 // initialize the JSON schema validator
 
 const schemas = require("../app/schemas");
 
-// query each URL expecting well-formed JSON matching the project schema structure
-for (const datafeed of datasources.urls) {
-  // Initialize summary counts
-  const datafeed_counts = {valid:0,invalid:0};
-  // Initialize invalid record tracking
-  const invalid_records = [];
+async function processDatafeeds() {
+  const feed_summary = {};
+  const invalid_feeds = {};
+  // query each URL expecting well-formed JSON matching the project schema structure
+  for (const datafeed of datasources.urls) {
+    // Initialize summary counts
+    const datafeed_counts = {valid:0,invalid:0};
+    // Initialize invalid record tracking
+    const invalid_records = [];
 
-  if (datafeed.url === null) {
-    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: missing URL)");
-    continue; // skip entire data feed
-  }
-
-  var datafeed_text;
-  try {
-    datafeed_text = fetch(datafeed.url).text();
-  } catch (err) {
-    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: retrieval failed)");
-    console.error(err.message);
-    continue; // skip entire data feed
-  }
-
-  // expect well-formed JSON
-  var datafeed_json;
-  try {
-    datafeed_json = JSON.parse(datafeed_text);
-  } catch (err) {
-    console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: malformed JSON)");
-    console.error(err.message);
-    continue; // skip entire data feed
-  }
-
-  // Each feed might conform to a different schema version.
-  // Look for a schema version at the top level of the JSON feed.
-  var schema_version = datafeed_json.schema_version;
-
-  // Adding the schema_version field at the top level moves the dataset array into a top-level field named 'datasets'.
-  // But if this field is not found, assume this is an older feed where the dataset array is at the top level.
-  var datasets = (datafeed_json.datasets === undefined) ? datafeed_json : datafeed_json.datasets;
-
-  // Look up the LinkML JSON schema.
-  const schema_filename = schemas.index[schema_version];
-
-  if (schema_filename === undefined)
-  {
-    console.error('Unsupported schema version: ' + schema_version + ' - skipping ' + datafeed.name + ' feed.');
-    continue; // skip to next feed
-  }
-
-  var validate; // the validator for this feed
-
-  try {
-    const schema = require('../app/schemas/' + schema_filename);
-    const ajv = new Ajv({ allErrors: 'true', verbose: 'true', strict: 'false' }); // must set option "strict: 'false'" to produce specification-compliant behavior
-    addFormats(ajv); // required for supporting format: date in JSON schema
-    validate = ajv.compile(schema);
-  } catch (err) {
-    console.error('Unable to load ' + schema_filename + ' - skipping ' + datafeed.name + ' feed.');
-    console.error(err.message);
-    continue; // skip to next feed
-  }
-
-  console.log('Validating ' + datafeed.name + ' against ' + schema_filename);
-
-  // validate the entire feed
-  try {
-    if (validate({ "datasets": [ datasets ] })) {
-      console.log(datafeed.name + "DATA FEED PASSED VALIDATION");
-    }
-  } catch (err) {
-    console.error(datafeed.name + "DATA FEED FAILED VALIDATION:", validate.errors);
-    // this is a non-fatal error, so continue processing records
-  }
-
-  // process each dataset in the data feed
-  datasets.forEach(function(dataset, dataset_index)
-  {
-    // handle malformed data gracefully (only reject individual datasets that fail validation, not entire data feeds)
-    if (validate({ "datasets": [ dataset ] })) {
-      datafeed_counts.valid += 1;
-    } else {
-      datafeed_counts.invalid += 1;
-      console.error("[" + datafeed.url + "]: DATA SET " + (dataset_index + 1) + " FAILED VALIDATION - identifier: " + dataset.identifier);
-      const dataset_errors = validate.errors.map(function(error){ return { msg: error.instancePath + ": " + error.message, provided: error.data, required: error.schema}; });
-      console.error(dataset_errors);
-      invalid_records.push([dataset.identifier+" ("+(dataset_index+1)+")", JSON.stringify(dataset_errors)]);
-      return; // only reject data sets that fail validation
+    if (datafeed.url === null) {
+      console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: missing URL)");
+      continue; // skip entire data feed
     }
 
-    const uid = dataset.brc + '_' + dataset.identifier;
+    var datafeed_text;
+    try {
+      datafeed_text = fetch(datafeed.url).text();
+    } catch (err) {
+      console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: retrieval failed)");
+      console.error(err.message);
+      continue; // skip entire data feed
+    }
 
-    const new_record = {
-      uid: uid,
-      schema_version: schema_version,
-      json: dataset
+    // expect well-formed JSON
+    var datafeed_json;
+    try {
+      datafeed_json = JSON.parse(datafeed_text);
+    } catch (err) {
+      console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: malformed JSON)");
+      console.error(err.message);
+      continue; // skip entire data feed
+    }
+
+    // Each feed might conform to a different schema version.
+    // Look for a schema version at the top level of the JSON feed.
+    var schema_version = datafeed_json.schema_version;
+
+    // Adding the schema_version field at the top level moves the dataset array into a top-level field named 'datasets'.
+    // But if this field is not found, assume this is an older feed where the dataset array is at the top level.
+    var datasets = (datafeed_json.datasets === undefined) ? datafeed_json : datafeed_json.datasets;
+
+    // Look up the LinkML JSON schema.
+    const schema_filename = schemas.index[schema_version];
+
+    if (schema_filename === undefined)
+    {
+      console.error('Unsupported schema version: ' + schema_version + ' - skipping ' + datafeed.name + ' feed.');
+      continue; // skip to next feed
+    }
+
+    var validate; // the validator for this feed
+
+    try {
+      const schema = require('../app/schemas/' + schema_filename);
+      const ajv = new Ajv({ allErrors: 'true', verbose: 'true', strict: 'false' }); // must set option "strict: 'false'" to produce specification-compliant behavior
+      addFormats(ajv); // required for supporting format: date in JSON schema
+      validate = ajv.compile(schema);
+    } catch (err) {
+      console.error('Unable to load ' + schema_filename + ' - skipping ' + datafeed.name + ' feed.');
+      console.error(err.message);
+      continue; // skip to next feed
+    }
+
+    console.log('Validating ' + datafeed.name + ' against ' + schema_filename);
+
+    // validate the entire feed
+    try {
+      if (validate({ "datasets": [ datasets ] })) {
+        console.log(datafeed.name + "DATA FEED PASSED VALIDATION");
+      }
+    } catch (err) {
+      console.error(datafeed.name + "DATA FEED FAILED VALIDATION:", validate.errors);
+      // this is a non-fatal error, so continue processing records
+    }
+
+    // process each dataset in the data feed
+    for (const [dataset_index, dataset] of Object.entries(datasets))
+    {
+      // handle malformed data gracefully (only reject individual datasets that fail validation, not entire data feeds)
+      if (validate({ "datasets": [ dataset ] })) {
+        datafeed_counts.valid += 1;
+      } else {
+        datafeed_counts.invalid += 1;
+        console.error("[" + datafeed.url + "]: DATA SET " + (dataset_index + 1) + " FAILED VALIDATION - identifier: " + dataset.identifier);
+        const dataset_errors = validate.errors.map(function(error){ return { msg: error.instancePath + ": " + error.message, provided: error.data, required: error.schema}; });
+        console.error(dataset_errors);
+        invalid_records.push([dataset.identifier+" ("+(dataset_index+1)+")", JSON.stringify(dataset_errors)]);
+        continue; // only reject data sets that fail validation
+      }
+
+      const uid = dataset.brc + '_' + dataset.identifier;
+
+      const new_record = {
+        uid: uid,
+        schema_version: schema_version,
+        json: dataset
+      };
+
+      await Dataset.scope('defaultScope').upsert(new_record);
     };
-
-    Dataset.scope('defaultScope').upsert(new_record);
-  });
-  feed_summary[datafeed.url]=datafeed_counts;
-  if (invalid_records.length > 0) {
-    invalid_feeds["Invalid Records - "+datafeed.name]=invalid_records;
-  };
+    feed_summary[datafeed.url]=datafeed_counts;
+    if (invalid_records.length > 0) {
+      invalid_feeds["Invalid Records - "+datafeed.name]=invalid_records;
+    };
+  }
+  console.log("Data Import Summary:", feed_summary);
+  return invalid_feeds;
 }
-console.log("Data Import Summary:", feed_summary);
-// Self executing async function
-(async () => {
+
+
+async function processInvalidRecords(invalid_feeds) {
   // Sync invalid data to Github issues
   Object.keys(invalid_feeds).forEach( title => {
     const issueBody = formatListWithSublistBlocks(invalid_feeds[title], 'json');
     syncIssueComment(title, issueBody, {labels: 'data-import'});
   });
+}
 
-})();
+async function main() {
+  console.log("Processing All Datafeeds");
+  const invalid = await processDatafeeds();
+
+  console.log("Processing Invalid Data");
+  await processInvalidRecords(invalid);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## What does this do
Fix for import errors on production.
Fixes #167 

Wait on each record update to avoid creating too many in-flight requests and potentially causing `ConnectionAcquireTimeoutError`

Wrapping the code in an `async` function to allow `await` makes the changes appear more significant than they were. The main change is:

```
await Dataset.scope('defaultScope').upsert(new_record);
```


## Testing
Reproducing the error locally requires slowdown on connections to the database. This can be simulated with TrafficControl `tc` command. To setup:

First, update local compose file to give `NET_ADMIN` capabilities to the container:
```yaml
api:
    cap_add:
    - NET_ADMIN
```

Then, start the stack with compose and run the following to add 500 ms of delay to each request:
```
docker compose exec api apt-get install -y iproute2
docker compose exec api tc qdisc add dev eth0 root netem delay 500ms
```

Now running the normal import command should reproduce the error, fixed with this PR:
```
docker compose exec api node scripts/import_datafeeds.js
```

## Related Issues

No Issue, hotfix for prod error.

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [ ] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
