### PR TITLE
check type of identifier before processing

### DIFF
--- a/api/scripts/import_datafeeds.js
+++ b/api/scripts/import_datafeeds.js
@@ -103,7 +103,7 @@ async function processDatafeeds() {
     for (const [dataset_index, dataset] of datasets.entries())
     {
       // Force error on empty string identifier
-      if(dataset.identifier?.trim() == ''){ dataset.identifier = null;}
+      if(typeof dataset.identifier === 'string' && dataset.identifier.trim() == ''){ dataset.identifier = null;}
       // handle malformed data gracefully (only reject individual datasets that fail validation, not entire data feeds)
       if (validate({ "datasets": [ dataset ] })) {
         datafeed_counts.valid += 1;


### PR DESCRIPTION
## What does this do
Fix bug in feed import. Check type of `identifier` value before running string specific function.

## Related Issues

Fixes #173 

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
