### PR TITLE
Revert temporary version change on GLBRC datafeed

### DIFF
--- a/api/app/config/datafeeds.json
+++ b/api/app/config/datafeeds.json
@@ -14,7 +14,7 @@
         },
         {
             "name": "GLBRC",
-            "url": "https://fair-data.glbrc.org/glbrc-0.1.10.json"
+            "url": "https://fair-data.glbrc.org/glbrc.json"
         }
     ]
 }


### PR DESCRIPTION
## What does this do
Revert temporary version changes to GLBRC datafeed URL. Use main feed location instead of `0.1.10` specific feed.

## Related Issues

Related to PR #171 

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [ ] My changes work as expected locally
- [ ] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
