### PR TITLE
Issue 189 - Add duplicate dataset links to UI.

### DIFF
--- a/api/app/controllers/dataset.controller.js
+++ b/api/app/controllers/dataset.controller.js
@@ -498,3 +498,77 @@ function buildCategoryWhere(categoryName) {
     }
   );
 }
+
+exports.lookupByUid = async (req, res) => {
+  try {
+    const uid = String(req.params.uid || "").trim();
+
+    if (!uid) {
+      return res.status(400).send({
+        message: "Dataset uid is required."
+      });
+    }
+
+    const sourceDataset = await Dataset.findByPk(uid);
+
+    if (!sourceDataset) {
+      return res.status(404).send({
+        message: "Dataset not found."
+      });
+    }
+
+    const identifier = String(sourceDataset.json?.identifier || "").trim();
+    const dataset_url = String(sourceDataset.json?.dataset_url || "").trim();
+
+    if (!identifier && !dataset_url) {
+      return res.status(400).send({
+        message: "Source dataset does not contain an identifier or dataset_url."
+      });
+    }
+
+    const conditions = [];
+
+    if (identifier) {
+      conditions.push(
+        db.Sequelize.where(
+          db.Sequelize.json("json.identifier"),
+          identifier
+        )
+      );
+    }
+
+    if (dataset_url) {
+      conditions.push(
+        db.Sequelize.where(
+          db.Sequelize.json("json.dataset_url"),
+          dataset_url
+        )
+      );
+    }
+
+    const datasets = await Dataset.findAll({
+      where: {
+        [db.Sequelize.Op.or]: conditions
+      },
+      order: [["uid", "ASC"]]
+    });
+
+    return res.send({
+      uid,
+      identifier: identifier || null,
+      dataset_url: dataset_url || null,
+      count: datasets.length,
+      datasets: datasets.map((dataset) => ({
+        uid: dataset.uid,
+        brc: dataset.json?.brc ?? null,
+        identifier: dataset.json?.identifier ?? null,
+        dataset_url: dataset.json?.dataset_url ?? null,
+        is_source: dataset.uid === uid
+      }))
+    });
+  } catch (err) {
+    return res.status(500).send({
+      message: err.message || "Some error occurred while retrieving datasets."
+    });
+  }
+};

--- a/api/app/routes/dataset.routes.js
+++ b/api/app/routes/dataset.routes.js
@@ -44,6 +44,95 @@
  *                 $ref: '#/components/schemas/Dataset'
  *      500:
  *        description: Some server error
+ * /api/datasets/lookup/{uid}:
+ *   get:
+ *     summary: Lookup related datasets using a source dataset uid
+ *     tags: [Datasets]
+ *     parameters:
+ *       - in: path
+ *         name: uid
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Dataset uid used to find related records by identifier and/or dataset URL
+ *         example: GLBRC_GSE218642
+ *     responses:
+ *       200:
+ *         description: Matching datasets and count
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 uid:
+ *                   type: string
+ *                   description: Source dataset uid used for the lookup
+ *                 identifier:
+ *                   type: string
+ *                   nullable: true
+ *                   description: Identifier extracted from the source dataset
+ *                 dataset_url:
+ *                   type: string
+ *                   nullable: true
+ *                   description: Dataset URL extracted from the source dataset
+ *                 count:
+ *                   type: integer
+ *                   description: Number of matching datasets
+ *                 datasets:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       uid:
+ *                         type: string
+ *                       brc:
+ *                         type: string
+ *                         nullable: true
+ *                       identifier:
+ *                         type: string
+ *                         nullable: true
+ *                       dataset_url:
+ *                         type: string
+ *                         nullable: true
+ *                       is_source:
+ *                          type: boolean
+ *                          description: Indicates whether this record is the source dataset used for the lookup
+ *               example:
+ *                 uid: GLBRC_GSE218642
+ *                 identifier: GSE218642
+ *                 dataset_url: null
+ *                 count: 2
+ *                 datasets:
+ *                   - uid: CABBI_GSE218642
+ *                     brc: CABBI
+ *                     identifier: GSE218642
+ *                     dataset_url: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE218642
+ *                   - uid: GLBRC_GSE218642
+ *                     brc: GLBRC
+ *                     identifier: GSE218642
+ *                     dataset_url: null
+ *       400:
+ *         description: Dataset uid is missing or the source dataset has neither identifier nor dataset URL
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       404:
+ *         description: Dataset not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 message: Dataset not found.
+ *       500:
+ *         description: Some server error
  * /api/datasets/{id}:
  *  get:
  *    summary: Get the dataset by id
@@ -62,7 +151,7 @@
  *          application/json:
  *            schema:
  *              $ref: '#/components/schemas/Dataset'
-* /api/datasets/metrics:
+ * /api/datasets/metrics:
  *  get:
  *    summary: Get dataset metrics
  *    responses:
@@ -97,6 +186,9 @@ router.get("/", datasets.findAll);
 
 // Retrieve aggregated metrics on Dataasets
 router.get("/metrics", datasets.getMetrics);
+
+// Lookup datasets by uid using the source dataset's identifier and/or dataset_url
+router.get("/lookup/:uid", datasets.lookupByUid);
 
 // POST /api/datasets -> search
 router.post("/", search);

--- a/api/scripts/import_datafeeds.js
+++ b/api/scripts/import_datafeeds.js
@@ -31,10 +31,6 @@ async function processDatafeeds() {
   const feed_summary = {};
   const invalid_feeds = {};
 
-  // Track dataset identifiers and URLs seen during this import run (across all feeds)
-  const processedIdentifiers = new Set();
-  const processedUrls = new Set();
-
   // query each URL expecting well-formed JSON matching the project schema structure
   for (const datafeed of datasources.urls) {
     // Initialize summary counts
@@ -42,6 +38,10 @@ async function processDatafeeds() {
     // Initialize invalid record tracking
     const invalid_records = [];
     const duplicate_records = [];
+
+    // Track dataset identifiers and URLs seen within current feed only.
+    const processedIdentifiers = new Set();
+    const processedUrls = new Set();
 
     if (datafeed.url === null) {
       console.error(datafeed.name + " [" + datafeed.url + "]: DATA FEED REJECTED (reason: missing URL)");
@@ -148,7 +148,10 @@ async function processDatafeeds() {
 
       if (duplicate) {
         datafeed_counts.duplicate += 1;
-        duplicate_records.push([dataset.identifier+" ("+(dataset_index+1)+")", JSON.stringify("identifier: " + dataset.identifier + ", dataset_url:" + dataset.dataset_url)]);
+        duplicate_records.push([
+          dataset.identifier + " (" + (dataset_index + 1) + ")",
+          "identifier: " + dataset.identifier + ", dataset_url: " + dataset.dataset_url
+        ]);
         continue; // skip adding the record
       }
 

--- a/api/scripts/import_datafeeds.js
+++ b/api/scripts/import_datafeeds.js
@@ -125,7 +125,7 @@ async function processDatafeeds() {
       var duplicate = false;
 
       // check for duplicate dataset identifiers
-      if (dataset.identifier !== null) {
+      if (dataset.identifier && dataset.identifier !== null) {
         const dedupeIdKey = (dataset.identifier).toString().trim().toLowerCase();
         if (processedIdentifiers.has(dedupeIdKey)) {
           console.warn("[" + datafeed.url + "]: DATA SET " + (dataset_index + 1) + " DUPLICATE - identifier: " + dataset.identifier);

--- a/api/tests/routes/dataset.routes.test.js
+++ b/api/tests/routes/dataset.routes.test.js
@@ -7,6 +7,7 @@ const db = require("../../app/models");
 // Replace db methods with mocks by mutating the shared module object
 const mockFindAndCountAll = vi.fn();
 const mockFindByPk = vi.fn();
+const mockFindAll = vi.fn();
 const mockCount = vi.fn();
 const mockQuery = vi.fn();
 
@@ -17,6 +18,9 @@ db.datasets.scope = vi.fn(() => ({
   count: mockCount,
   getTableName: () => "datasets",
 }));
+
+db.datasets.findByPk = mockFindByPk;
+db.datasets.findAll = mockFindAll;
 
 // Override sequelize.query for metrics and facet queries
 db.sequelize.query = mockQuery;
@@ -345,6 +349,113 @@ describe("dataset routes", () => {
         .send({ query: "test" });
       expect(res.status).toBe(500);
       expect(res.body.message).toContain("Search failed");
+    });
+  });
+
+  describe("GET /api/datasets/lookup/:uid", () => {
+    it("returns related datasets for a source dataset uid", async () => {
+      mockFindByPk.mockResolvedValue({
+        uid: "GLBRC_GSE218642",
+        json: {
+          identifier: "GSE218642",
+          dataset_url: "",
+        },
+      });
+
+      mockFindAll.mockResolvedValue([
+        {
+          uid: "CABBI_GSE218642",
+          json: {
+            brc: "CABBI",
+            identifier: "GSE218642",
+            dataset_url: "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE218642",
+          },
+        },
+        {
+          uid: "GLBRC_GSE218642",
+          json: {
+            brc: "GLBRC",
+            identifier: "GSE218642",
+            dataset_url: null,
+          },
+        },
+      ]);
+
+      const res = await supertest(app).get("/api/datasets/lookup/GLBRC_GSE218642");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        uid: "GLBRC_GSE218642",
+        identifier: "GSE218642",
+        dataset_url: null,
+        count: 2,
+        datasets: [
+          {
+            uid: "CABBI_GSE218642",
+            brc: "CABBI",
+            identifier: "GSE218642",
+            dataset_url: "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE218642",
+            is_source: false,
+          },
+          {
+            uid: "GLBRC_GSE218642",
+            brc: "GLBRC",
+            identifier: "GSE218642",
+            dataset_url: null,
+            is_source: true,
+          },
+        ],
+      });
+    });
+
+    it("returns 404 when source dataset is not found", async () => {
+      mockFindByPk.mockResolvedValue(null);
+
+      const res = await supertest(app).get("/api/datasets/lookup/DOES_NOT_EXIST");
+
+      expect(res.status).toBe(404);
+      expect(res.body.message).toContain("Dataset not found");
+    });
+
+    it("returns 400 when source dataset has neither identifier nor dataset_url", async () => {
+      mockFindByPk.mockResolvedValue({
+        uid: "EMPTY_SOURCE",
+        json: {
+          identifier: "",
+          dataset_url: "",
+        },
+      });
+
+      const res = await supertest(app).get("/api/datasets/lookup/EMPTY_SOURCE");
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain("identifier or dataset_url");
+    });
+
+    it("returns 500 when source dataset lookup fails", async () => {
+      mockFindByPk.mockRejectedValue(new Error("db error"));
+
+      const res = await supertest(app).get("/api/datasets/lookup/GLBRC_GSE218642");
+
+      expect(res.status).toBe(500);
+      expect(res.body.message).toContain("db error");
+    });
+
+    it("returns 500 when related dataset lookup fails", async () => {
+      mockFindByPk.mockResolvedValue({
+        uid: "GLBRC_GSE218642",
+        json: {
+          identifier: "GSE218642",
+          dataset_url: "",
+        },
+      });
+
+      mockFindAll.mockRejectedValue(new Error("db error"));
+
+      const res = await supertest(app).get("/api/datasets/lookup/GLBRC_GSE218642");
+
+      expect(res.status).toBe(500);
+      expect(res.body.message).toContain("db error");
     });
   });
 });

--- a/client/src/services/DatasetDataService.js
+++ b/client/src/services/DatasetDataService.js
@@ -15,6 +15,10 @@ class DatasetDataService {
     return http.get(`/datasets/${encodeURIComponent(id)}`);
   }
 
+  lookup(uid) {
+    return http.get(`/datasets/lookup/${encodeURIComponent(uid)}`);
+  }
+
   runAdvancedSearch(filter, sequence) {
     const payload = { query: filter, sequence: sequence };
     return http.post('/datasets/', payload);

--- a/client/src/views/DatasetShowView.vue
+++ b/client/src/views/DatasetShowView.vue
@@ -59,7 +59,7 @@ watchEffect( async () => {
 <template>
   <HeaderView />
   <div class="container">
-    <div v-if="dataset && !loading">
+    <div v-if="dataset && !datasetLoading">
       <div class="card mt-4">
         <div class="card-body">
           <div v-if="relatedDatasets.length > 0" class="mb-3 small">

--- a/client/src/views/DatasetShowView.vue
+++ b/client/src/views/DatasetShowView.vue
@@ -18,20 +18,41 @@ const dataset = ref(null);
 const datasetLoading = ref(true);
 const datasetLoadError = ref(null);
 
+const relatedDatasets = ref([]);
+const relatedDatasetsLoading = ref(false);
+const relatedDatasetsError = ref(null);
+
 watchEffect( async () => {
-  console.log("DatasetShow id param - ",props.id)
-  datasetLoadError.value = null
-  datasetLoading.value = true
-  if (!props.id) return
+  console.log("DatasetShow id param - ",props.id);
+  datasetLoadError.value = null;
+  datasetLoading.value = true;
+  relatedDatasets.value = [];
+  relatedDatasetsError.value = null;
+
+  if (!props.id) return;
+
   try {
     const response = await DatasetDataService.get(props.id);
-    dataset.value = response.data
+    dataset.value = response.data;
+
+    relatedDatasetsLoading.value = true;
+    try {
+      const lookupResponse = await DatasetDataService.lookup(props.id);
+      relatedDatasets.value = (lookupResponse.data?.datasets || []).filter(
+        (item: any) => !item.is_source
+      );
+    } catch (e) {
+      relatedDatasetsError.value = e;
+      relatedDatasets.value = [];
+    } finally {
+      relatedDatasetsLoading.value = false;
+    }
   } catch (e) {
     datasetLoadError.value = e
   } finally {
     datasetLoading.value = false
   }
-})
+});
 
 </script>
 
@@ -41,8 +62,23 @@ watchEffect( async () => {
     <div v-if="dataset && !loading">
       <div class="card mt-4">
         <div class="card-body">
+          <div v-if="relatedDatasets.length > 0" class="mb-3 small">
+            <span class="text-muted">This dataset is also catalogued as:</span>
+            <span v-for="(item, index) in relatedDatasets" :key="item.uid">
+              <span v-if="index > 0">, </span>
+              <router-link :to="`/datasets/${item.uid}`">
+                {{ item.uid }}
+              </router-link>
+            </span>
+          </div>
+
           <component :is="resolveComponentVersion(dataset)"  :selectedResult="dataset"></component>
-          <router-link :to="{ name: 'datasetSearch', query: searchStore.lastSearchQuery }" class="card-link btn btn-dark rounded-pill px-3 pe-4 fw-bold fs-5 mt-2"><i class="bi bi-arrow-left pe-3" aria-hidden="true"></i> Return</router-link>
+          <router-link
+            :to="{ name: 'datasetSearch', query: searchStore.lastSearchQuery }"
+            class="card-link btn btn-dark rounded-pill px-3 pe-4 fw-bold fs-5 mt-2"
+          >
+            <i class="bi bi-arrow-left pe-3" aria-hidden="true"></i> Return
+          </router-link>
         </div>
       </div>
     </div>
@@ -50,5 +86,4 @@ watchEffect( async () => {
 </template>
 
 <style scoped>
-
 </style>


### PR DESCRIPTION
## What does this do

- Added API endpoint to look up all catalogued datasets matching the specified dataset's `identifier` and/or `dataset_url`) across all feeds.
- Added link to duplicate datasets in other feeds.
- Fixed incorrect variable name in `DatasetShowView.vue`.
- Added unit tests for new API endpoint.

## Related Issues

Fixes #189

## Screenshots

API: [GLBRC_GSE218642](http://localhost:8080/api/datasets/lookup/GLBRC_GSE218642)

<img width="563" height="441" alt="Screenshot 2026-03-24 at 18-39-23 " src="https://github.com/user-attachments/assets/b69d7ffa-0c01-4890-b9f0-24ca0b56861f" />

View: [GLBRC_GSE218642](http://localhost:3000/datasets/GLBRC_GSE218642)

<img width="989" height="362" alt="Screenshot 2026-03-24 at 18-42-23 Bioenergy" src="https://github.com/user-attachments/assets/53b6cd4f-3b72-4c1a-add6-cee1dd0b0149" />

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [x] I updated user documentation (if applicable)
