### PR TITLE
Fix uid column size to avoid SequelizeDatabaseError for uids longer than 255 chars

### DIFF
--- a/api/app/models/dataset.model.js
+++ b/api/app/models/dataset.model.js
@@ -18,7 +18,7 @@ module.exports = (sequelize, Sequelize) => {
   Dataset.init(
     {
       uid: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         allowNull: false,
         primaryKey: true
       },


### PR DESCRIPTION
## What does this do

- Changed `uid` column from `DataTypes.STRING` to `DataTypes.TEXT`.

**Note:** `STRING` columns in Sequlize result in a `CHAR(255)` SQL column by default. Changing the datatype to TEXT will require either a SQL update to the production database, or a drop / re-create database.

## Related Issues

Fixes #201

## Screenshots

```
Data Import Summary: {
  'https://bioenergy.org/JBEI/jbei.json': { valid: 1688, invalid: 93, duplicate: 1 },
  'https://cabbitools.igb.illinois.edu/brc/cabbi.json': { valid: 269, invalid: 0, duplicate: 0 },
  'https://fair.ornl.gov/CBI/cbi.json': { valid: 130, invalid: 0, duplicate: 0 },
  'https://fair-data.glbrc.org/glbrc.json': { valid: 225, invalid: 0, duplicate: 0 }
}
```

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
