### PR TITLE
Added localhost entries to CORS list for local testing.

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -11,7 +11,7 @@ const schemaRoutes = require('./app/routes/schema.routes');
 const app = express();
 
 var corsOptions = {
-  origin: [process.env.BIOENERGY_ORG_CLIENT_URI, "https://api.bioenergy.org", "https://bioenergy.org", "https://www.bioenergy.org"]
+  origin: [process.env.BIOENERGY_ORG_CLIENT_URI, "https://api.bioenergy.org", "http://localhost:3000", "http://localhost:8081", "http://localhost:8080", "https://bioenergy.org", "https://www.bioenergy.org"]
 };
 
 // Apply global middleware for all routes first


### PR DESCRIPTION
## What does this do

Fixes regression in CORS behavior to allow local testing of web site and API.
Adds the following entries to CORS options:
- http://localhost:3000
- http://localhost:8081
- http://localhost:8080

## Related Issues

Fixes #203 

## Screenshots

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
