### PR TITLE
Added json index to datasets.

### DIFF
--- a/api/app/models/dataset.model.js
+++ b/api/app/models/dataset.model.js
@@ -41,7 +41,19 @@ module.exports = (sequelize, Sequelize) => {
     },
     { 
       sequelize,
-      modelName: 'dataset'
+      modelName: 'dataset',
+      indexes: [
+        {
+          name: 'dataset_json_full_ts_gin_idx',
+          using: 'GIN',
+          fields: [
+            Sequelize.literal(
+              `to_tsvector('simple', "json"::text)`
+            )
+          ]
+
+        }
+      ]
     }
   );
 


### PR DESCRIPTION
## What does this do
Demonstrates facet query speed improvement using an index on `json` column data.
- This improves query time in my local tests: ~3 seconds for the full page load vs ~10s
- This does not seem like enough improvement in my opinion to switch to automatic refresh when interacting with filters as discussed in #213

## Related Issues

#213 (partial fix)

Related to PR #219

## Screenshots

- `7,234.339 ms` [Original Query](https://explain.depesz.com/s/Pi3To)
- `2,009.042 ms` [With Index](https://explain.depesz.com/s/tY0c)

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [x] I updated the Changelog (if applicable)
- [x] I added tests with appropriate coverage and verified they all pass (if applicable)
- [x] I updated user documentation (if applicable)
