### PR TITLE
Updated CBI feed location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ docker compose -f docker-compose.dev.yml build --no-cache client
 ## BRC Data End Points
 
 - CABBI: <https://cabbitools.igb.illinois.edu/brc/cabbi.json>
-- CBI: <https://fair.ornl.gov/CBI/cbi.json>
+- CBI: <https://bioenergy-research-centers.github.io/brc_data_feeds/cbi.json>
 - GLBRC: <https://fair-data.glbrc.org/glbrc.json>
 - JBEI: <https://bioenergy.org/JBEI/jbei.json>
 

--- a/api/app/config/datafeeds.json
+++ b/api/app/config/datafeeds.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "CBI",
-            "url": "https://fair.ornl.gov/CBI/cbi.json"
+            "url": "https://bioenergy-research-centers.github.io/brc_data_feeds/cbi.json"
         },
         {
             "name": "GLBRC",


### PR DESCRIPTION
## What does this do

Changes CBI data feed from https://fair.ornl.gov/CBI/cbi.json to https://bioenergy-research-centers.github.io/brc_data_feeds/cbi.json.

## Related Issues

Fixes #237

## Screenshots

```
Processing All Datafeeds
Validating JBEI against brc_schema_0.1.12.json
JBEI DATA FEED PASSED VALIDATION
Validating CABBI against brc_schema_0.1.13.json
CABBI DATA FEED PASSED VALIDATION
Validating CBI against brc_schema_0.1.15.json
CBI DATA FEED PASSED VALIDATION
Validating GLBRC against brc_schema_0.1.15.json
GLBRC DATA FEED PASSED VALIDATION

Data Import Summary: {
  'https://bioenergy.org/JBEI/jbei.json': { valid: 1782, invalid: 0, duplicate: 0 },
  'https://cabbitools.igb.illinois.edu/brc/cabbi.json': { valid: 388, invalid: 0, duplicate: 0 },
  'https://bioenergy-research-centers.github.io/brc_data_feeds/cbi.json': { valid: 446, invalid: 0, duplicate: 0 },
  'https://fair-data.glbrc.org/glbrc.json': { valid: 225, invalid: 0, duplicate: 0 }
}
```

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [x] I updated user documentation (if applicable)
