### PR TITLE
Adds publication date range to faceted search.

### DIFF
--- a/api/app/controllers/dataset.controller.js
+++ b/api/app/controllers/dataset.controller.js
@@ -13,6 +13,8 @@ exports.findAll = async (req, res) => {
       rows: req.query.rows,
       limit: req.query.limit,
       nofacets: req.query.nofacets,
+      from_date: req.query.from_date,
+      until_date: req.query.until_date,
     });
 
     res.json(results);

--- a/api/app/controllers/search.controller.js
+++ b/api/app/controllers/search.controller.js
@@ -2,8 +2,8 @@ const strategyManager = require('../services/strategyManager');
 const datasetsService = require("../services/datasetsService");
 
 async function search(req, res) {
-    const { query, sequence, page, rows, limit, filters, nofacets } = req.body;
-    console.log('running search', query, sequence, page, rows, limit, filters, nofacets);
+    const { query, sequence, page, rows, limit, filters, nofacets, from_date, until_date } = req.body;
+    console.log('running search', query, sequence, page, rows, limit, filters, nofacets, from_date, until_date);
 
     try {
         if (sequence && sequence.trim() !== '') {
@@ -20,6 +20,8 @@ async function search(req, res) {
           limit,
           filters,
           nofacets,
+          from_date,
+          until_date,
         });
 
         return res.json(localResults);

--- a/api/app/routes/dataset.routes.js
+++ b/api/app/routes/dataset.routes.js
@@ -134,6 +134,20 @@
  *                 type: string
  *         description: Filter by dataset year
  *       - in: query
+ *         name: from_date
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: 2025-01-01
+ *         description: Include datasets with publication date on or after this date
+ *       - in: query
+ *         name: until_date
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: 2025-12-31
+ *         description: Include datasets with publication date on or before this date
+ *       - in: query
  *         name: filters[personName]
  *         schema:
  *           oneOf:
@@ -220,6 +234,14 @@
  *               nofacets:
  *                 type: boolean
  *                 description: Exclude facets from local dataset search response
+ *               from_date:
+ *                 type: string
+ *                 format: date
+ *                 description: Include datasets with publication date on or after this date
+ *               until_date:
+ *                 type: string
+ *                 format: date
+ *                 description: Include datasets with publication date on or before this date
  *               filters:
  *                 type: object
  *                 description: Optional local dataset search filters

--- a/api/app/services/datasetsService.js
+++ b/api/app/services/datasetsService.js
@@ -26,6 +26,8 @@ async function searchLocalDatasets(params = {}) {
   const speciesQueryTerm = params.speciesQueryTerm ?? filters.species;
   const analysisTypeQueryTerm = params.analysisTypeQueryTerm ?? filters.analysisType;
   const themeQueryTerm = params.themeQueryTerm ?? filters.theme;
+  const fromDateQueryTerm = params.fromDateQueryTerm ?? params.from_date ?? filters.from_date;
+  const untilDateQueryTerm = params.untilDateQueryTerm ?? params.until_date ?? filters.until_date;
 
   const includeFacets = !parseBooleanParam(params.nofacets);
   const { page, limit, offset } = getPaginationParams(params);
@@ -36,6 +38,8 @@ async function searchLocalDatasets(params = {}) {
     brcQueryTerm,
     categoryQueryTerm,
     yearQueryTerm,
+    fromDateQueryTerm,
+    untilDateQueryTerm,
     personNameQueryTerm,
     repositoryQueryTerm,
     speciesQueryTerm,
@@ -93,6 +97,8 @@ function buildDatasetSearchConditions({
   brcQueryTerm,
   categoryQueryTerm,
   yearQueryTerm,
+  fromDateQueryTerm,
+  untilDateQueryTerm,
   personNameQueryTerm,
   repositoryQueryTerm,
   speciesQueryTerm,
@@ -259,6 +265,24 @@ function buildDatasetSearchConditions({
                 ],
             });
         }
+    }
+
+    if (fromDateQueryTerm) {
+        conditions.push({
+            [Op.and]: [
+                where(db.Sequelize.json("json.date"), { [Op.regexp]: "^\\d{4}-\\d{2}-\\d{2}$" }),
+                where(db.Sequelize.json("json.date"), { [Op.gte]: fromDateQueryTerm }),
+            ],
+        });
+    }
+
+    if (untilDateQueryTerm) {
+        conditions.push({
+            [Op.and]: [
+                where(db.Sequelize.json("json.date"), { [Op.regexp]: "^\\d{4}-\\d{2}-\\d{2}$" }),
+                where(db.Sequelize.json("json.date"), { [Op.lte]: untilDateQueryTerm }),
+            ],
+        });
     }
 
     if (personNameQueryTerm) {

--- a/api/tests/controllers/dataset.controller.test.js
+++ b/api/tests/controllers/dataset.controller.test.js
@@ -1,0 +1,21 @@
+const datasetsController = require("../../app/controllers/dataset.controller");
+
+describe("dataset.controller lookupByUid", () => {
+  it("returns 400 when uid is missing", async () => {
+    const req = {
+      params: {},
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    await datasetsController.lookupByUid(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({
+      message: "Dataset uid is required.",
+    });
+  });
+});

--- a/api/tests/controllers/validate.controller.test.js
+++ b/api/tests/controllers/validate.controller.test.js
@@ -1,0 +1,53 @@
+const { validateUploadedFeed } = require("../../app/controllers/validate.controller");
+
+describe("validateUploadedFeed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 500 when an unexpected error occurs", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const req = {
+      body: {
+        schema_version: "0.1.15",
+        datasets: [],
+      },
+      query: null,
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await validateUploadedFeed(req, res);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Internal server error",
+    });
+  });
+
+  it("returns 400 when request body is missing", async () => {
+    const req = {
+      body: undefined,
+      query: {},
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await validateUploadedFeed(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Request body must be valid JSON",
+    });
+  });
+});

--- a/api/tests/models/dataset.model.test.js
+++ b/api/tests/models/dataset.model.test.js
@@ -1,75 +1,51 @@
-const sanitizeHtml = require("sanitize-html");
-
-const ALLOWED_HTML = { allowedTags: ["b", "i", "sub", "sup"], allowedAttributes: {} };
+const db = require("../../app/models");
 
 describe("Dataset model", () => {
+  const Dataset = db.datasets;
+
   describe("toClientJSON", () => {
     it("merges schema_version, uid, and timestamps into the json object", () => {
-      // Simulate what toClientJSON does without needing Sequelize
-      const instance = {
-        json: { title: "Test Dataset", brc: "GLBRC" },
-        schema_version: "0.1.15",
+      const instance = Dataset.build({
         uid: "abc-123",
-        createdAt: new Date("2025-01-01"),
-        updatedAt: new Date("2025-06-01"),
-        toClientJSON() {
-          const jsonData = this.json;
-          jsonData.schema_version = this.schema_version;
-          jsonData.uid = this.uid;
-          jsonData.created_at = this.createdAt;
-          jsonData.updated_at = this.updatedAt;
-          return jsonData;
+        schema_version: "0.1.15",
+        json: {
+          title: "Test Dataset",
+          brc: "GLBRC",
         },
-      };
+      });
+
+      instance.createdAt = new Date("2025-01-01");
+      instance.updatedAt = new Date("2025-06-01");
 
       const result = instance.toClientJSON();
-      expect(result.title).toBe("Test Dataset");
-      expect(result.brc).toBe("GLBRC");
-      expect(result.schema_version).toBe("0.1.15");
-      expect(result.uid).toBe("abc-123");
+
+      expect(result).toMatchObject({
+        title: "Test Dataset",
+        brc: "GLBRC",
+        schema_version: "0.1.15",
+        uid: "abc-123",
+      });
       expect(result.created_at).toEqual(new Date("2025-01-01"));
       expect(result.updated_at).toEqual(new Date("2025-06-01"));
     });
   });
 
   describe("json field sanitization", () => {
-    // Directly test the sanitization logic used by the model setter
-    function sanitizeJSON(rawJSON) {
-      return JSON.parse(
-        JSON.stringify(rawJSON, (_key, value) =>
-          typeof value === "string" ? sanitizeHtml(value, ALLOWED_HTML) : value
-        )
-      );
-    }
-
-    it("strips disallowed HTML tags from string values", () => {
-      const result = sanitizeJSON({ title: "<script>alert(1)</script>Hello" });
-      expect(result.title).toBe("Hello");
-      expect(result.title).not.toContain("<script>");
-    });
-
-    it("allows permitted tags (b, i, sub, sup)", () => {
-      const result = sanitizeJSON({ title: "H<sub>2</sub>O is <b>water</b>" });
-      expect(result.title).toBe("H<sub>2</sub>O is <b>water</b>");
-    });
-
-    it("does not modify non-string values", () => {
-      const result = sanitizeJSON({ count: 42, active: true, tags: ["a", "b"] });
-      expect(result.count).toBe(42);
-      expect(result.active).toBe(true);
-      expect(result.tags).toEqual(["a", "b"]);
-    });
-
-    it("sanitizes nested string values", () => {
-      const result = sanitizeJSON({
-        creator: [{ name: "<img onerror=alert(1)>Dr. Smith" }],
+    it("sanitizes string values through the model setter", () => {
+      const instance = Dataset.build({
+        uid: "sanitize-1",
+        json: {
+          title: "<script>alert(1)</script>Hello",
+          desc: "H<sub>2</sub>O is <b>water</b>",
+          creator: [{ name: "<img onerror=alert(1)>Dr. Smith" }],
+          count: 42,
+        },
       });
-      expect(result.creator[0].name).toBe("Dr. Smith");
-    });
 
-    it("strips div and span tags but keeps text", () => {
-      const result = sanitizeJSON({ desc: "<div>Some <span>text</span></div>" });
-      expect(result.desc).toBe("Some text");
+      expect(instance.json.title).toBe("Hello");
+      expect(instance.json.desc).toBe("H<sub>2</sub>O is <b>water</b>");
+      expect(instance.json.creator[0].name).toBe("Dr. Smith");
+      expect(instance.json.count).toBe(42);
     });
   });
 });

--- a/api/tests/routes/dataset.routes.test.js
+++ b/api/tests/routes/dataset.routes.test.js
@@ -56,7 +56,7 @@ describe("dataset routes", () => {
   describe("GET /api/datasets", () => {
     it("passes query params to searchLocalDatasets", async () => {
       const res = await supertest(app).get(
-        "/api/datasets?q=ethanol&page=2&rows=25&filters[brc]=JBEI&nofacets=true"
+        "/api/datasets?q=ethanol&page=2&rows=25&filters[brc]=JBEI&nofacets=true&from_date=2025-01-01&until_date=2025-12-31"
       );
 
       expect(res.status).toBe(200);
@@ -70,6 +70,8 @@ describe("dataset routes", () => {
         rows: "25",
         limit: undefined,
         nofacets: "true",
+        from_date: "2025-01-01",
+        until_date: "2025-12-31",
       });
     });
 
@@ -438,5 +440,23 @@ describe("dataset routes", () => {
     });
 
     expect(mockFindAll).toHaveBeenCalled();
+  });
+
+  it("passes date range query params to searchLocalDatasets", async () => {
+    const res = await supertest(app).get(
+      "/api/datasets?q=ethanol&from_date=2025-01-01&until_date=2025-12-31"
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSearchLocalDatasets).toHaveBeenCalledWith({
+      textQueryTerm: "ethanol",
+      filters: undefined,
+      page: undefined,
+      rows: undefined,
+      limit: undefined,
+      nofacets: undefined,
+      from_date: "2025-01-01",
+      until_date: "2025-12-31",
+    });
   });
 });

--- a/api/tests/services/datasetsService.test.js
+++ b/api/tests/services/datasetsService.test.js
@@ -478,4 +478,38 @@ describe("searchLocalDatasets", () => {
 
     expect(db.sequelize.query).not.toHaveBeenCalled();
   });
+
+  it("adds from_date condition when from_date is provided", async () => {
+    await datasetsService.searchLocalDatasets({
+      from_date: "2025-01-01",
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+
+    expect(callArgs.where).not.toEqual({});
+  });
+
+  it("adds until_date condition when until_date is provided", async () => {
+    await datasetsService.searchLocalDatasets({
+      until_date: "2025-12-31",
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+
+    expect(callArgs.where).not.toEqual({});
+  });
+
+  it("adds date range conditions when from_date and until_date are provided", async () => {
+    await datasetsService.searchLocalDatasets({
+      from_date: "2025-01-01",
+      until_date: "2025-12-31",
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+
+    expect(callArgs.where).not.toEqual({});
+  });
 });

--- a/client/src/__tests__/services/DatasetDataService.test.js
+++ b/client/src/__tests__/services/DatasetDataService.test.js
@@ -16,9 +16,9 @@ describe('DatasetDataService', () => {
 
   describe('getAll', () => {
     it('calls GET /datasets with pagination and query params', () => {
-      DatasetDataService.getAll({ page: 2, rows: 25, query: 'ethanol', filters: { brc: 'JBEI' } });
+      DatasetDataService.getAll({ page: 2, rows: 25, query: 'ethanol', filters: { brc: 'JBEI' }, from_date: '2025-01-01', until_date: '2025-12-31', });
       expect(http.get).toHaveBeenCalledWith('/datasets', {
-        params: { page: 2, rows: 25, q: 'ethanol', filters: { brc: 'JBEI' }, nofacets: undefined },
+        params: { page: 2, rows: 25, q: 'ethanol', filters: { brc: 'JBEI' }, nofacets: undefined, from_date: '2025-01-01', until_date: '2025-12-31' },
       });
     });
 
@@ -39,7 +39,7 @@ describe('DatasetDataService', () => {
     it('works with no options', () => {
       DatasetDataService.getAll();
       expect(http.get).toHaveBeenCalledWith('/datasets', {
-        params: { page: undefined, rows: undefined, q: undefined, filters: undefined, nofacets: undefined },
+        params: { page: undefined, rows: undefined, q: undefined, filters: undefined, nofacets: undefined, from_date: undefined, until_date: undefined },
       });
     });
   });

--- a/client/src/__tests__/store/searchStore.test.js
+++ b/client/src/__tests__/store/searchStore.test.js
@@ -121,6 +121,8 @@ describe('searchStore', () => {
         rows: 50,
         query: 'ethanol',
         filters: {},
+        from_date: undefined,
+        until_date: undefined,
       });
       expect(store.searchResults).toEqual([{ uid: '1', title: 'Dataset A' }]);
       expect(store.totalPages).toBe(3);
@@ -247,5 +249,80 @@ describe('searchStore', () => {
       store.goToPage(-3);
       expect(store.currentPage).toBe(1);
     });
+  });
+
+  it('passes publication date range to getAll', async () => {
+    mockGetAll.mockResolvedValue({
+      data: {
+        items: [],
+        totalPages: 1,
+        totalResults: 0,
+        query: { page: 1 },
+        facets: {},
+      },
+    });
+
+    store.searchTerm = 'ethanol';
+    store.fromDate = '2025-01-01';
+    store.untilDate = '2025-12-31';
+
+    await store.runSearch(false);
+
+    expect(mockGetAll).toHaveBeenCalledWith({
+      page: 1,
+      rows: 50,
+      query: 'ethanol',
+      filters: {},
+      from_date: '2025-01-01',
+      until_date: '2025-12-31',
+    });
+  });
+
+  it('imports date range from query', () => {
+    store.importFromURLQuery({
+      from_date: '2025-01-01',
+      until_date: '2025-12-31',
+    });
+
+    expect(store.fromDate).toBe('2025-01-01');
+    expect(store.untilDate).toBe('2025-12-31');
+  });
+
+  it('clears date range state', () => {
+    store.fromDate = '2025-01-01';
+    store.untilDate = '2025-12-31';
+
+    store.clearSearchData();
+
+    expect(store.fromDate).toBe('');
+    expect(store.untilDate).toBe('');
+  });
+
+  it('adds date range to URL query', async () => {
+    store.searchTerm = 'ethanol';
+    store.fromDate = '2025-01-01';
+    store.untilDate = '2025-12-31';
+
+    await store.applySearchToURL();
+
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'datasetSearch',
+      query: expect.objectContaining({
+        q: 'ethanol',
+        from_date: '2025-01-01',
+        until_date: '2025-12-31',
+        rows: 50,
+      }),
+    });
+  });
+
+  it('detects date range URL changes', () => {
+    store.fromDate = '2025-01-01';
+    store.untilDate = '2025-12-31';
+
+    expect(store.anyQueryURLChanges({
+      from_date: '2025-01-01',
+      until_date: '2025-12-30',
+    })).toBe(true);
   });
 });

--- a/client/src/__tests__/store/searchStore.test.js
+++ b/client/src/__tests__/store/searchStore.test.js
@@ -199,8 +199,8 @@ describe('searchStore', () => {
       expect(store.filters).toBeUndefined();
     });
 
-    it('parses page and size from query', () => {
-      store.importFromURLQuery({ page: '3', size: '25' });
+    it('parses page and rows from query', () => {
+      store.importFromURLQuery({ page: '3', rows: '25' });
       expect(store.currentPage).toBe(3);
       expect(store.pageSize).toBe(25);
     });
@@ -324,5 +324,31 @@ describe('searchStore', () => {
       from_date: '2025-01-01',
       until_date: '2025-12-30',
     })).toBe(true);
+  });
+
+  it('imports page size from rows query param', () => {
+    store.importFromURLQuery({
+      page: '2',
+      rows: '25',
+    });
+
+    expect(store.currentPage).toBe(2);
+    expect(store.pageSize).toBe(25);
+  });
+
+  it('does not report URL changes when numeric pagination state matches string query params', () => {
+    store.currentPage = 2;
+    store.pageSize = 25;
+    store.searchTerm = 'ethanol';
+    store.filters = {};
+
+    const result = store.anyQueryURLChanges({
+      q: 'ethanol',
+      filters: JSON.stringify({}),
+      page: '2',
+      rows: '25',
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/client/src/services/DatasetDataService.js
+++ b/client/src/services/DatasetDataService.js
@@ -8,7 +8,9 @@ class DatasetDataService {
     const q = options.query || options.q;
     const filters = options.filters;
     const nofacets = options.nofacets;
-    return http.get("/datasets", { params: { page, rows, q, filters, nofacets } });
+    const from_date = options.from_date;
+    const until_date = options.until_date;
+    return http.get("/datasets", { params: { page, rows, q, filters, nofacets, from_date, until_date } });
   }
 
   get(id) {

--- a/client/src/store/searchStore.js
+++ b/client/src/store/searchStore.js
@@ -13,6 +13,8 @@ export const useSearchStore = defineStore('searchStore', () => {
   const searchResultsError = ref(null);
   const filters = ref({});
   const searchTerm = ref('');
+  const fromDate = ref('');
+  const untilDate = ref('');
 
   // page state
   const defaultPageSize = 50;
@@ -76,6 +78,8 @@ export const useSearchStore = defineStore('searchStore', () => {
     searchResults.value = [];
     filterChanges.value = true;
     resultPage.value = 1;
+    fromDate.value = '';
+    untilDate.value = '';
   }
 
   // Retrieve results matching current search filters and store in searchResults
@@ -104,7 +108,9 @@ export const useSearchStore = defineStore('searchStore', () => {
           page: currentPage.value,
           rows: pageSize.value,
           query: searchTerm.value,
-          filters: filters.value
+          filters: filters.value,
+          from_date: fromDate.value || undefined,
+          until_date: untilDate.value || undefined,
         });
       }
       // Handle paginated response shape
@@ -154,6 +160,8 @@ export const useSearchStore = defineStore('searchStore', () => {
         ...route.query,
         q: (searchTerm.value && searchTerm.value.length > 0) ? searchTerm.value : undefined,
         filters: (jsonFilterString && jsonFilterString.length > 0) ? jsonFilterString : undefined,
+        from_date: fromDate.value || undefined,
+        until_date: untilDate.value || undefined,
         page: currentPage.value !== 1 ? currentPage.value : undefined,
         rows: pageSize.value
       }
@@ -175,6 +183,8 @@ export const useSearchStore = defineStore('searchStore', () => {
     } else {
       filters.value = undefined;
     }
+    fromDate.value = query.from_date || '';
+    untilDate.value = query.until_date || '';
     currentPage.value = parseInt(query.page) > 0 ? parseInt(query.page) : 1;
     pageSize.value = parseInt(query.size) > 0 ? parseInt(query.size) : defaultPageSize;
   }
@@ -186,7 +196,9 @@ export const useSearchStore = defineStore('searchStore', () => {
       const sameFilters = JSON.stringify(filters.value) === query.filters;
       const sameSearch = searchTerm.value === query.q;
       const samePage = (currentPage.value === query.page && pageSize.value === query.rows);
-      return !(sameSearch && sameFilters && samePage);
+      const sameFromDate = (fromDate.value || undefined) === query.from_date;
+      const sameUntilDate = (untilDate.value || undefined) === query.until_date;
+      return !(sameSearch && sameFilters && samePage && sameFromDate && sameUntilDate);
     } catch (e) {
       console.error("searchStore URL comparison error.", e);
       return false;
@@ -223,6 +235,8 @@ export const useSearchStore = defineStore('searchStore', () => {
     totalPages,
     totalResults,
     facets,
+    fromDate,
+    untilDate,
     // actions
     runSearch,
     clearSearchData,

--- a/client/src/store/searchStore.js
+++ b/client/src/store/searchStore.js
@@ -186,7 +186,7 @@ export const useSearchStore = defineStore('searchStore', () => {
     fromDate.value = query.from_date || '';
     untilDate.value = query.until_date || '';
     currentPage.value = parseInt(query.page) > 0 ? parseInt(query.page) : 1;
-    pageSize.value = parseInt(query.size) > 0 ? parseInt(query.size) : defaultPageSize;
+    pageSize.value = parseInt(query.rows) > 0 ? parseInt(query.rows) : defaultPageSize;
   }
 
   // Compare current state to provided value
@@ -195,7 +195,10 @@ export const useSearchStore = defineStore('searchStore', () => {
     try {
       const sameFilters = JSON.stringify(filters.value) === query.filters;
       const sameSearch = searchTerm.value === query.q;
-      const samePage = (currentPage.value === query.page && pageSize.value === query.rows);
+      const samePage = (
+        currentPage.value === (parseInt(query.page) > 0 ? parseInt(query.page) : 1) &&
+        pageSize.value === (parseInt(query.rows) > 0 ? parseInt(query.rows) : defaultPageSize)
+      );
       const sameFromDate = (fromDate.value || undefined) === query.from_date;
       const sameUntilDate = (untilDate.value || undefined) === query.until_date;
       return !(sameSearch && sameFilters && samePage && sameFromDate && sameUntilDate);

--- a/client/src/views/SearchResults.vue
+++ b/client/src/views/SearchResults.vue
@@ -142,6 +142,31 @@ const onPageChange = (newPage) => {
                   <FacetFilterChecks title="Year" label="year" :items="facets?.year" v-model="searchStore.year" alphabetical reverse />
                 </div>
 
+                <!-- Publication Date Filter -->
+                <div class="mb-3">
+                  <span class="h5">Publication Date</span>
+
+                  <div class="mt-2">
+                    <label class="form-label small text-muted" for="from-date-filter">From</label>
+                    <input
+                      id="from-date-filter"
+                      type="date"
+                      class="form-control form-control-sm"
+                      v-model="searchStore.fromDate"
+                    />
+                  </div>
+
+                  <div class="mt-2">
+                    <label class="form-label small text-muted" for="until-date-filter">Until</label>
+                    <input
+                      id="until-date-filter"
+                      type="date"
+                      class="form-control form-control-sm"
+                      v-model="searchStore.untilDate"
+                    />
+                  </div>
+                </div>
+
                 <!-- Species Filter -->
                 <div class="mb-2">
                   <FacetFilterDatalist title="Species" label="species" :items="facets?.species" v-model="searchStore.species" placeholder="e.g., Escherichia coli, Sorghum bicolor"/>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -42,22 +42,24 @@ GET /api/datasets/:uid
 
 ### list_datasets
 
-List datasets with pagination.
+### search_datasets
+
+Search datasets by free text and optional metadata filters, including publication date range.
 
 Maps to:
 
 ```
-GET /api/datasets?limit=&offset=
+GET /api/datasets?page=&rows=&q=&from_date=&until_date=
 ```
 
 ### search_datasets
 
-Search datasets by free text.
+Search datasets by free text and optional metadata filters.
 
 Maps to:
 
 ```
-GET /api/datasets?page=&rows=&q=
+GET /api/datasets?page=&rows=&q=&from_date=&until_date=
 ```
 
 ## Environment Variables
@@ -159,9 +161,10 @@ curl http://localhost:8081/mcp \
     "method": "tools/call",
     "params": {
       "name": "list_datasets",
-      "arguments": {
-        "limit": 5,
-        "offset": 0
+        "arguments": {
+          "page": 1,
+          "rows": 5
+        }
       }
     }
   }'
@@ -176,7 +179,6 @@ curl http://localhost:8081/mcp \
 
 ## Potential Future Improvements
 
-- Add search/filter tools
 - Add write operations (create/update/delete) with proper auth
 - Add request logging and rate limiting
 - Add MCP resources (`dataset://{uid}`)

--- a/mcp/src/server.js
+++ b/mcp/src/server.js
@@ -122,7 +122,7 @@ function createServer() {
 
   server.tool(
     "search_datasets",
-    "Search datasets by free-text query and optional metadata filters. Use this to find datasets by keyword, analysis type, BRC, and other supported filter fields.",
+    "Search datasets by free-text query and optional metadata filters. Use this to find datasets by keyword, publication date, analysis type, BRC, and other supported filter fields.",
     {
       q: z
         .string()
@@ -148,9 +148,17 @@ function createServer() {
       brc: z
         .array(z.string())
         .optional()
-        .describe('Optional list of BRC filters, for example ["JBEI"] or ["JBEI", "CABBI"]. The complete set of BRCs are: ["JBEI", "CABBI", "CBI", "GLBRC"].')
+        .describe('Optional list of BRC filters, for example ["JBEI"] or ["JBEI", "CABBI"]. The complete set of BRCs are: ["JBEI", "CABBI", "CBI", "GLBRC"].'),
+      from_date: z
+        .string()
+        .optional()
+        .describe("Optional publication date lower bound in YYYY-MM-DD format. Includes datasets published on or after this date."),
+      until_date: z
+        .string()
+        .optional()
+        .describe("Optional publication date upper bound in YYYY-MM-DD format. Includes datasets published on or before this date.")
     },
-    async ({ q, page, rows, analysisType, brc }) => {
+    async ({ q, page, rows, analysisType, brc, from_date, until_date }) => {
       try {
         const params = {
           q,
@@ -166,6 +174,14 @@ function createServer() {
           brc.forEach((value, index) => {
             params[`filters[brc][${index}]`] = value;
           });
+        }
+
+        if (from_date) {
+          params.from_date = from_date;
+        }
+
+        if (until_date) {
+          params.until_date = until_date;
         }
 
         const response = await api.get("/api/datasets", { params });


### PR DESCRIPTION
## What does this do

- Adds searching by publication date range to API.
- Adds publication date range to faceted search in UI.
- Adds test coverage to API and client.
- Fixes pagination bug in UI.
- Adds date filtering to MCP.

## Related Issues

Fixes #235

## Screenshots

To check the pagination UI fix, visit http://localhost:3000/search?from_date=2026-01-01&rows=25&page=2 and confirm that rows 26-50 are shown instead of 51-100.

**Screenshot.** Filtering by publication dates.

<img width="1498" height="1033" alt="date_search" src="https://github.com/user-attachments/assets/c2135a14-ca36-4cee-8721-f25826f1dc54" />

**Screenshot.** Filtering by publication dates in MCP server (via MCP Inspector).

<img width="1369" height="1781" alt="MCP_Inspector_date_filter" src="https://github.com/user-attachments/assets/afd541a1-a91c-468c-be04-5f5dd8f34061" />

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [x] I updated the Changelog (if applicable)
- [x] I added tests with appropriate coverage and verified they all pass (if applicable)
- [x] I updated user documentation (if applicable)
