### PR TITLE
Faceted search query performance enhancements.

### DIFF
--- a/api/app/models/index.js
+++ b/api/app/models/index.js
@@ -2,7 +2,7 @@ const dbConfig = require("../config/db.config.js");
 
 const Sequelize = require("sequelize");
 const sequelize = new Sequelize(dbConfig.DB, dbConfig.USER, dbConfig.PASSWORD, {
-    logging: false, // disable logging; default: console.log
+    logging: console.log, // disable logging; default: console.log
     host: dbConfig.HOST,
     port: dbConfig.PORT,
     dialect: dbConfig.dialect,

--- a/api/app/models/index.js
+++ b/api/app/models/index.js
@@ -2,7 +2,7 @@ const dbConfig = require("../config/db.config.js");
 
 const Sequelize = require("sequelize");
 const sequelize = new Sequelize(dbConfig.DB, dbConfig.USER, dbConfig.PASSWORD, {
-    logging: console.log, // disable logging; default: console.log
+    logging: false, // disable logging; default: console.log
     host: dbConfig.HOST,
     port: dbConfig.PORT,
     dialect: dbConfig.dialect,

--- a/api/app/services/datasetsService.js
+++ b/api/app/services/datasetsService.js
@@ -1,6 +1,5 @@
 const db = require("../models");
 const { getPaginationParams } = require("../utils/pagination");
-const keywordCategories = require("../utils/categories");
 const Dataset = db.datasets;
 const {Op, where} = db.Sequelize;
 
@@ -19,7 +18,7 @@ async function searchLocalDatasets(params = {}) {
   const textQueryTerm = params.textQueryTerm;
   const titleQueryTerm = params.titleQueryTerm ?? filters.title;
   const brcQueryTerm = params.brcQueryTerm ?? filters.brc;
-  const categoryQueryTerm = params.categoryQueryTerm ?? filters.topic;
+  const topicQueryTerm = params.topicQueryTerm ?? filters.topic;
   const yearQueryTerm = params.yearQueryTerm ?? filters.year;
   const personNameQueryTerm = params.personNameQueryTerm ?? filters.personName;
   const repositoryQueryTerm = params.repositoryQueryTerm ?? filters.repository;
@@ -36,7 +35,7 @@ async function searchLocalDatasets(params = {}) {
     textQueryTerm,
     titleQueryTerm,
     brcQueryTerm,
-    categoryQueryTerm,
+    topicQueryTerm,
     yearQueryTerm,
     fromDateQueryTerm,
     untilDateQueryTerm,
@@ -95,7 +94,7 @@ function buildDatasetSearchConditions({
   textQueryTerm,
   titleQueryTerm,
   brcQueryTerm,
-  categoryQueryTerm,
+  topicQueryTerm,
   yearQueryTerm,
   fromDateQueryTerm,
   untilDateQueryTerm,
@@ -238,11 +237,8 @@ function buildDatasetSearchConditions({
         }
     }
 
-    if (categoryQueryTerm) {
-        const categoryCondition = buildCategoryWhere(categoryQueryTerm);
-        if (categoryCondition) {
-            conditions.push(categoryCondition);
-        }
+    if (topicQueryTerm) {
+        conditions.push(buildStoredTopicWhere(topicQueryTerm));
     }
 
     if (yearQueryTerm) {
@@ -321,31 +317,14 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
     const baseSelectSql = db.sequelize.dialect.queryGenerator.selectQuery(scoped.getTableName(), {
       model: scoped,
       where: mergedWhereConditions,
-      attributes: ["uid"], 
+      attributes: ["uid"],
+      tableAs: "dataset",
     }).slice(0, -1); // remove trailing ';'
-
-    // Build static SQL values and bind variables for CTE table of categories (name, queryBind)
-    const categoryNames = Object.keys(keywordCategories);
-    const categoryReplacements = {};
-    const categoryValuesSql = categoryNames
-      .map((name, i) => {
-        const bindKey = `cat_query_${i}`;
-        const categoryTsquery = buildCategoryTsquery(name) || "";
-        categoryReplacements[bindKey] = categoryTsquery;
-        return `(${db.sequelize.escape(name)}, :${bindKey})`;
-      })
-      .join(",\n        ");
 
     // Use the scoped filtered rows in CTE to filter counted rows for facets
     const facetSql = `
       WITH filtered_datasets AS (
         ${baseSelectSql}
-      ),
-      categories AS (
-        SELECT * FROM (VALUES
-          ${categoryValuesSql}
-        ) AS c(name, qtext)
-        WHERE NULLIF(BTRIM(qtext), '') IS NOT NULL
       ),
       personNames AS (
         SELECT d.uid, COALESCE(NULLIF(BTRIM(c.elem->>'name'), ''), 'NA') AS name
@@ -423,13 +402,13 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
         UNION ALL
 
         SELECT 'topic' AS facet,
-              c.name AS value,
-              COUNT(*)::int AS count
+          replace(jsonb_array_elements_text(d."json"->'topic'), '&amp;', '&') AS value,
+          COUNT(*)::int AS count
         FROM datasets d
         JOIN filtered_datasets f ON f.uid = d.uid
-        JOIN categories c
-        ON to_tsvector('simple', d."json"::text) @@ to_tsquery('simple', c.qtext)
-        GROUP BY c.name
+        WHERE jsonb_typeof(d."json"->'topic') = 'array'
+          AND jsonb_array_length(d."json"->'topic') > 0
+        GROUP BY value
 
         UNION ALL
 
@@ -444,7 +423,10 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
       ) x
       ORDER BY count DESC;
     `;
-    const rows = await db.sequelize.query(facetSql, { type: db.sequelize.QueryTypes.SELECT, replacements: categoryReplacements});
+
+    const rows = await db.sequelize.query(facetSql, {
+      type: db.sequelize.QueryTypes.SELECT,
+    });
     const facets = { year: [], brc: [], repository: [], species: [], analysisType: [], personName: [], topic: [], theme: [] };
     for (const r of rows) facets[r.facet].push({ value: r.value, count: r.count });
     return facets;
@@ -454,60 +436,19 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
   }
 }
 
-// Convert category keyword into a tsquery fragment
-function keywordToTsqueryFragment(keyword) {
-  const tokens = String(keyword)
-    .toLowerCase()
-    .trim()
-    .split(/[\s\-_]+/g)
-    .filter(Boolean);
+function buildStoredTopicWhere(topicName) {
+  const topics = (Array.isArray(topicName) ? topicName : [topicName])
+  .filter(Boolean);
 
-  if (tokens.length === 0) return null;
-  if (tokens.length === 1) return tokens[0];
-
-  // '<->' is postgres "followed by" operator for phrase style keywords
-  // https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
-  return `(${tokens.join(" <-> ")})`;
-}
-
-// Build a tsquery string for one category
-function buildCategoryTsquery(categoryName) {
-  const keywords = keywordCategories[categoryName];
-  if (!Array.isArray(keywords) || keywords.length === 0) return null;
-
-  const frags = keywords
-    .map(keywordToTsqueryFragment)
-    .filter(Boolean);
-
-  if (frags.length === 0) return null;
-
-  // OR across keywords within a category.
-  return frags.join(" | ");
-}
-
-// Create a Sequelize where() condition for a category.
-function buildCategoryWhere(categoryName) {
-  let q = null;
-  if(Array.isArray(categoryName)) {
-    // OR across all keywords for multiple selected categories
-    q = categoryName.map(cat => { return buildCategoryTsquery(cat); })
-                    .filter(c => {return (c && c.length>0);})
-                    .join(" | ");
-  } else {
-    q = buildCategoryTsquery(categoryName);
-  }
-    
-  if (!q) return null;
+  const escapedTopics = topics.map((t) => db.sequelize.escape(t)).join(", ");
 
   return where(
-    db.Sequelize.fn(
-      "to_tsvector",
-      "simple",
-      db.Sequelize.cast(db.Sequelize.col("json"), "text")
-    ),
-    {
-      [Op.match]: db.Sequelize.fn("to_tsquery", "simple", q),
-    }
+    db.Sequelize.literal(`EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements_text("dataset"."json"->'topic') AS t(value)
+      WHERE replace(t.value, '&amp;', '&') IN (${escapedTopics})
+    )`),
+    true
   );
 }
 

--- a/api/app/services/datasetsService.js
+++ b/api/app/services/datasetsService.js
@@ -238,7 +238,11 @@ function buildDatasetSearchConditions({
     }
 
     if (topicQueryTerm) {
-        conditions.push(buildStoredTopicWhere(topicQueryTerm));
+        const topicCondition = buildStoredTopicWhere(topicQueryTerm);
+
+        if (topicCondition) {
+            conditions.push(topicCondition);
+        }
     }
 
     if (yearQueryTerm) {
@@ -438,9 +442,16 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
 
 function buildStoredTopicWhere(topicName) {
   const topics = (Array.isArray(topicName) ? topicName : [topicName])
-  .filter(Boolean);
+    .map((topic) => String(topic).trim())
+    .filter(Boolean);
 
-  const escapedTopics = topics.map((t) => db.sequelize.escape(t)).join(", ");
+  if (!topics.length) {
+    return null;
+  }
+
+  const escapedTopics = topics
+    .map((topic) => db.sequelize.escape(topic))
+    .join(", ");
 
   return where(
     db.Sequelize.literal(`EXISTS (

--- a/api/tests/routes/dataset.routes.test.js
+++ b/api/tests/routes/dataset.routes.test.js
@@ -459,4 +459,19 @@ describe("dataset routes", () => {
       until_date: "2025-12-31",
     });
   });
+
+  it("passes topic filters to searchLocalDatasets", async () => {
+    const res = await supertest(app).get(
+      "/api/datasets?filters[topic]=Microbiology&filters[topic]=Plant%20Biology"
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSearchLocalDatasets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: {
+          topic: ["Microbiology", "Plant Biology"],
+        },
+      })
+    );
+  });
 });

--- a/api/tests/services/datasetsService.test.js
+++ b/api/tests/services/datasetsService.test.js
@@ -227,9 +227,9 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).not.toEqual({});
   });
 
-  it("adds topic/category condition when categoryQueryTerm is provided", async () => {
+  it("adds topic condition when topicQueryTerm is provided", async () => {
     await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: "Microbiology",
+      topicQueryTerm: "Microbiology",
       nofacets: true,
     });
 
@@ -406,9 +406,9 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).not.toEqual({});
   });
 
-  it("adds topic/category condition when categoryQueryTerm is an array", async () => {
+  it("adds topic condition when topicQueryTerm is an array", async () => {
     await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: ["Microbiology", "Plant Biology"],
+      topicQueryTerm: ["Microbiology", "Plant Biology"],
       nofacets: true,
     });
 
@@ -417,9 +417,9 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).not.toEqual({});
   });
 
-  it("ignores empty category arrays", async () => {
+  it("ignores an empty topic array", async () => {
     await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: [],
+      topicQueryTerm: [],
       nofacets: true,
     });
 
@@ -428,9 +428,20 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).toEqual({});
   });
 
-  it("ignores unknown category names", async () => {
+  it("adds a condition for an arbitrary topic value", async () => {
     await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: "UnknownCategory",
+      topicQueryTerm: "Unknown Topic",
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+
+    expect(callArgs.where).not.toEqual({});
+  });
+
+  it("ignores an array containing only empty topic values", async () => {
+    await datasetsService.searchLocalDatasets({
+      topicQueryTerm: [""],
       nofacets: true,
     });
 
@@ -439,26 +450,15 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).toEqual({});
   });
 
-  it("ignores empty category query values", async () => {
+  it("adds a condition using only non-empty topic values", async () => {
     await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: [""],
+      topicQueryTerm: ["", "Microbiology"],
       nofacets: true,
     });
 
     const callArgs = mockFindAndCountAll.mock.calls[0][0];
 
-    expect(callArgs.where).toEqual({});
-  });
-
-  it("ignores empty and unknown category filters", async () => {
-    await datasetsService.searchLocalDatasets({
-      categoryQueryTerm: ["", "Unknown Category"],
-      nofacets: true,
-    });
-
-    const callArgs = mockFindAndCountAll.mock.calls[0][0];
-
-    expect(callArgs.where).toEqual({});
+    expect(callArgs.where).not.toEqual({});
   });
 
   it("includes facets when nofacets is false string", async () => {

--- a/api/tests/services/datasetsService.test.js
+++ b/api/tests/services/datasetsService.test.js
@@ -512,4 +512,51 @@ describe("searchLocalDatasets", () => {
 
     expect(callArgs.where).not.toEqual({});
   });
+
+  
+  it("builds stored-topic SQL with HTML entity normalization", async () => {
+    const literalSpy = vi.spyOn(db.Sequelize, "literal");
+
+    await datasetsService.searchLocalDatasets({
+      topicQueryTerm: "Analytics & Methods",
+      nofacets: true,
+    });
+
+    expect(literalSpy).toHaveBeenCalledWith(
+      expect.stringContaining("replace(t.value, '&amp;', '&')")
+    );
+    expect(literalSpy).toHaveBeenCalledWith(
+      expect.stringContaining("'Analytics & Methods'")
+    );
+
+    literalSpy.mockRestore();
+  });
+
+  it("generates facet SQL using the dataset alias for topic filters", async () => {
+    await datasetsService.searchLocalDatasets({
+      topicQueryTerm: "Microbiology",
+    });
+
+    expect(
+      db.sequelize.dialect.queryGenerator.selectQuery
+    ).toHaveBeenCalledWith(
+      "datasets",
+      expect.objectContaining({
+        tableAs: "dataset",
+        attributes: ["uid"],
+      })
+    );
+  });
+
+  it("normalizes HTML entities in topic facet values", async () => {
+    db.sequelize.query.mockResolvedValue([]);
+
+    await datasetsService.searchLocalDatasets({});
+
+    const facetSql = db.sequelize.query.mock.calls[0][0];
+
+    expect(facetSql).toContain(
+      `replace(jsonb_array_elements_text(d."json"->'topic'), '&amp;', '&')`
+    );
+  });
 });


### PR DESCRIPTION
## What does this do

Improves the performance of topic filtering by replacing the previous dynamic full-text category derivation with direct filtering against the stored `json.topic` field. This eliminates the expensive `to_tsvector()`/`to_tsquery()` operations while preserving existing search behavior. This also removes support for the obsolete category queries.

- Replaced dynamic topic filtering with exact matching against the stored `json.topic` array.
- Replaced dynamic topic facet generation with aggregation over the stored `json.topic` values.
- Renamed the internal `categoryQueryTerm` variable to `topicQueryTerm` to reflect the underlying data model.
- Normalized HTML entity encoding (`&amp;` ↔ `&`) so topic filters generated by the home page match stored topic values.
- Updated the facet query to use the appropriate table alias when applying topic filters.

## Related Issues

- Fixes #213
- This PR replaces Draft PR #219, which was based on an outdated code base and will be deleted.

## Screenshots

- Reduced the faceted search query execution time from approximately **7.2 seconds** to **314 ms**.
- Reduced topic facet generation time from approximately **6.9 seconds** to **43 ms**.
- Eliminated expensive full-text searches for topic filtering in favor of indexed JSON processing.
- Preserved existing search results and facet behavior while substantially improving response time.

Refer to the new Execution Plan at [explain.depesz.com](https://explain.depesz.com/s/ljPwK) if needed.

## Acceptance

Add an 'x' to the boxes below if they are complete
- [x] My changes work as expected locally
- [x] My changes are related to existing issues or other approved work
- [x] I updated the Changelog (if applicable)
- [x] I added tests with appropriate coverage and verified they all pass (if applicable)
- [x] I updated user documentation (if applicable)
