### PR TITLE
Address author list height

### DIFF
--- a/client/src/__tests__/components/AuthorList.test.js
+++ b/client/src/__tests__/components/AuthorList.test.js
@@ -14,6 +14,18 @@ describe('AuthorList', () => {
     expect(wrapper.text()).toContain('Dr. Jones');
   });
 
+  it('renders only the configured number of creators', () => {
+    const wrapper = mount(AuthorList, { props: { creators, maxVisible: 1 } });
+    expect(wrapper.text()).toContain('Dr. Smith');
+    expect(wrapper.text()).not.toContain('Dr. Jones');
+  });
+
+  it('renders all creators when maxVisible is invalid', () => {
+    const wrapper = mount(AuthorList, { props: { creators, maxVisible: 1.5 } });
+    expect(wrapper.text()).toContain('Dr. Smith');
+    expect(wrapper.text()).toContain('Dr. Jones');
+  });
+
   it('shows email icon only for primary contacts', () => {
     const wrapper = mount(AuthorList, { props: { creators } });
     const envelopeIcons = wrapper.findAll('.bi-envelope');

--- a/client/src/components/AuthorList.vue
+++ b/client/src/components/AuthorList.vue
@@ -1,10 +1,25 @@
 <script setup>
   import { computed } from 'vue';
-  const props = defineProps(['creators']);
+  const props = defineProps({
+    creators: {
+      type: Array,
+      default: () => [],
+    },
+    maxVisible: {
+      type: Number,
+      default: null,
+    },
+  });
 
-  const primaryCreators = computed(() => {
+  const creators = computed(() => {
     if(!Array.isArray(props.creators)) { return []; }
-    return props.creators.filter(item => item.primaryContact === true);
+    if (
+      !Number.isInteger(props.maxVisible) ||
+      props.maxVisible < 0
+    ) {
+      return props.creators;
+    }
+    return props.creators.slice(0, props.maxVisible);
   });
   const contactTooltip = (creator) => {
     return `Corresponding Contact: ${creator.email || 'No e-mail address provided.'}`
@@ -13,7 +28,7 @@
 
 <template>
   <div>
-    <template v-for="(creator, index) in creators">
+    <template v-for="(creator, index) in creators" :key="creator.name + index">
       <div class="d-inline-flex align-items-baseline me-2">
 
         <span class="me-1">{{ creator.name }}</span>

--- a/client/src/utils/pluralize.ts
+++ b/client/src/utils/pluralize.ts
@@ -1,0 +1,2 @@
+export const pluralizeAuthors = (count: number): string =>
+  count === 1 ? 'author' : 'authors';

--- a/client/src/views/DataHomeView.vue
+++ b/client/src/views/DataHomeView.vue
@@ -7,6 +7,7 @@ import { useRoute } from 'vue-router'
 import DatasetDataService from "../services/DatasetDataService";
 import sanitizeHtml from 'sanitize-html';
 import { useSearchStore } from '@/store/searchStore';
+import { pluralizeAuthors } from '@/utils/pluralize';
 
 import heroBg from "@/assets/hero-bg.png";
 import speciesIcon from "@/assets/species-icon.png";
@@ -30,6 +31,7 @@ const recentDataLoading = ref(false)
 const error = ref(null)
 const dataMetrics = ref(null)
 const metricsLoading = ref(false)
+const recentDatasetAuthorMaxVisible = 3;
 
 async function loadRecentData() {
   recentDataLoading.value = true
@@ -422,7 +424,17 @@ const applySuggestedQuery = () => {
                       v-html="sanitizeHtml(truncateMiddle(result.title || 'Untitled data set', 75, 50), ALLOWED_HTML)"></span>
                   </h5>
                   <div class="card-author mb-3 text-start">
-                    <AuthorList :creators="result.creator" />
+                    <AuthorList
+                      :creators="result.creator"
+                      :max-visible="recentDatasetAuthorMaxVisible"
+                    />
+                    <span
+                      v-if="Array.isArray(result.creator) && result.creator.length > recentDatasetAuthorMaxVisible"
+                      class="small text-muted"
+                    >
+                      +{{ result.creator.length - recentDatasetAuthorMaxVisible }} more
+                      {{ pluralizeAuthors(result.creator.length - recentDatasetAuthorMaxVisible) }}
+                    </span>
                   </div>
                   <p class="card-text text-start fst-italic">
                     <span

--- a/client/src/views/SearchResults.vue
+++ b/client/src/views/SearchResults.vue
@@ -16,6 +16,7 @@ import FacetFilterDatalist from '@/components/FacetFilterDatalist.vue';
 
 const route = useRoute()
 const searchStore = useSearchStore();
+const searchAuthorMaxVisible = 3;
 
 const ALLOWED_HTML = { allowedTags: [ 'b', 'i', 'sub', 'sup'], allowedAttributes: {} };
 
@@ -263,7 +264,17 @@ const onPageChange = (newPage) => {
 
                   <div class="row">
                     <div class="fs-6 fw-light">
-                      <AuthorList :creators="result.creator" />
+                      <AuthorList
+                        :creators="result.creator"
+                        :max-visible="searchAuthorMaxVisible"
+                      />
+                      <router-link
+                        v-if="Array.isArray(result.creator) && result.creator.length > searchAuthorMaxVisible"
+                        :to="{ name: 'datasetShow', params: { id: result.uid } }"
+                        class="small"
+                      >
+                        +{{ result.creator.length - searchAuthorMaxVisible }} more
+                      </router-link>
                     </div>
                   </div>
 

--- a/client/src/views/SearchResults.vue
+++ b/client/src/views/SearchResults.vue
@@ -13,6 +13,7 @@ import {BPagination, BSpinner} from 'bootstrap-vue-next'
 import FacetCharts from '@/components/FacetCharts.vue';
 import FacetFilterChecks from '@/components/FacetFilterChecks.vue';
 import FacetFilterDatalist from '@/components/FacetFilterDatalist.vue';
+import { pluralizeAuthors } from '@/utils/pluralize';
 
 const route = useRoute()
 const searchStore = useSearchStore();
@@ -268,13 +269,13 @@ const onPageChange = (newPage) => {
                         :creators="result.creator"
                         :max-visible="searchAuthorMaxVisible"
                       />
-                      <router-link
+                      <span
                         v-if="Array.isArray(result.creator) && result.creator.length > searchAuthorMaxVisible"
-                        :to="{ name: 'datasetShow', params: { id: result.uid } }"
-                        class="small"
+                        class="small text-muted"
                       >
                         +{{ result.creator.length - searchAuthorMaxVisible }} more
-                      </router-link>
+                        {{ pluralizeAuthors(result.creator.length - searchAuthorMaxVisible) }}
+                      </span>
                     </div>
                   </div>
 


### PR DESCRIPTION
## What does this do

Limits author lists to 3 visible authors and displays a singularized/pluralized +N more author(s) on the homepage and search results page.


## Related Issues

Fixes #254 

## Screenshots

Homepage, Recent Datasets card:

<img width="244" height="149" alt="image" src="https://github.com/user-attachments/assets/7c315774-e91b-4cd8-bb63-7fd6f34dc388" />

Search Results: 

<img width="714" height="510" alt="image" src="https://github.com/user-attachments/assets/27758ef8-9802-4477-b43d-6b34c9711a41" />

## Acceptance

Add an 'x' to the boxes below if they are complete
- [ ] My changes work as expected locally
- [ ] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [ ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
