### PR TITLE
Fix Filters/Facets personName search to query json.contributors, not json.contributor

### DIFF
--- a/api/app/services/datasetsService.js
+++ b/api/app/services/datasetsService.js
@@ -294,7 +294,7 @@ function buildDatasetSearchConditions({
                     where(db.Sequelize.json("json.creator"), {
                         [Op.iLike]: { [Op.any]: personNameQueryTermMapping },
                     }),
-                     where(db.Sequelize.json("json.contributor"), {
+                     where(db.Sequelize.json("json.contributors"), {
                         [Op.iLike]: { [Op.any]: personNameQueryTermMapping },
                     }),
                 ],
@@ -303,7 +303,7 @@ function buildDatasetSearchConditions({
             conditions.push({
                 [Op.or]: [
                     where(db.Sequelize.json("json.creator"), { [Op.iLike]: `%${personNameQueryTerm}%` }),
-                    where(db.Sequelize.json("json.contributor"), { [Op.iLike]: `%${personNameQueryTerm}%` }),
+                    where(db.Sequelize.json("json.contributors"), { [Op.iLike]: `%${personNameQueryTerm}%` }),
                 ],
             });
         }
@@ -343,8 +343,8 @@ async function runFacetQuery({ Dataset, mergedWhereConditions }) {
         SELECT d.uid, COALESCE(NULLIF(BTRIM(cn.elem->>'name'), ''), 'NA') AS name
         FROM datasets d
         JOIN filtered_datasets f ON f.uid = d.uid
-        CROSS JOIN LATERAL jsonb_array_elements(d."json"->'contributor') AS cn(elem)
-        WHERE jsonb_typeof(d."json"->'contributor') = 'array'
+        CROSS JOIN LATERAL jsonb_array_elements(d."json"->'contributors') AS cn(elem)
+        WHERE jsonb_typeof(d."json"->'contributors') = 'array'
           AND jsonb_typeof(cn.elem) = 'object'
       )
       SELECT facet, value, count

--- a/api/tests/services/datasetsService.test.js
+++ b/api/tests/services/datasetsService.test.js
@@ -260,6 +260,21 @@ describe("searchLocalDatasets", () => {
     expect(callArgs.where).not.toEqual({});
   });
 
+  it("matches against the schema's json.contributors field, not json.contributor", async () => {
+    await datasetsService.searchLocalDatasets({
+      personNameQueryTerm: "Smith",
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+    const [creatorClause, contributorsClause] = callArgs.where[db.Sequelize.Op.and][0][
+      db.Sequelize.Op.or
+    ];
+
+    expect(creatorClause.attribute.path).toBe("json.creator");
+    expect(contributorsClause.attribute.path).toBe("json.contributors");
+  });
+
   it("supports filters object", async () => {
     await datasetsService.searchLocalDatasets({
       filters: {
@@ -404,6 +419,21 @@ describe("searchLocalDatasets", () => {
 
     const callArgs = mockFindAndCountAll.mock.calls[0][0];
     expect(callArgs.where).not.toEqual({});
+  });
+
+  it("matches against json.contributors, not json.contributor, when personNameQueryTerm is an array", async () => {
+    await datasetsService.searchLocalDatasets({
+      personNameQueryTerm: ["Smith", "Jones"],
+      nofacets: true,
+    });
+
+    const callArgs = mockFindAndCountAll.mock.calls[0][0];
+    const [creatorClause, contributorsClause] = callArgs.where[db.Sequelize.Op.and][0][
+      db.Sequelize.Op.or
+    ];
+
+    expect(creatorClause.attribute.path).toBe("json.creator");
+    expect(contributorsClause.attribute.path).toBe("json.contributors");
   });
 
   it("adds topic condition when topicQueryTerm is an array", async () => {
@@ -558,5 +588,16 @@ describe("searchLocalDatasets", () => {
     expect(facetSql).toContain(
       `replace(jsonb_array_elements_text(d."json"->'topic'), '&amp;', '&')`
     );
+  });
+
+  it("builds the personName facet against json.contributors, not json.contributor", async () => {
+    await datasetsService.searchLocalDatasets({});
+
+    const facetSql = db.sequelize.query.mock.calls[0][0];
+
+    expect(facetSql).toContain(
+      `jsonb_array_elements(d."json"->'contributors') AS cn(elem)`
+    );
+    expect(facetSql).toContain(`jsonb_typeof(d."json"->'contributors') = 'array'`);
   });
 });


### PR DESCRIPTION
## What does this do
Minor: All three supported content schemas define the field as `contributors` (plural), but the personName filter and facet query used the singular `contributor`, which never exists in the JSON. People listed only under contributors (not creator) were silently excluded from personName search and the personName facet, despite the UI claiming both are searched.

Strengthens the existing personName tests to assert on the actual query path/SQL instead of just checking the where clause is non-empty, so they would have caught this.

## Related Issues
Fixes #258

## Screenshots
<img width="1263" height="774" alt="personSearch-fix" src="https://github.com/user-attachments/assets/b0c3cfc2-288c-4819-bc0d-0d350562a821" />


## Acceptance

Add an 'x' to the boxes below if they are complete
- [X ] My changes work as expected locally
- [X ] My changes are related to existing issues or other approved work
- [ ] I updated the Changelog (if applicable)
- [X ] I added tests with appropriate coverage and verified they all pass (if applicable)
- [ ] I updated user documentation (if applicable)
