### PR TITLE
Run CI on Node 24 to fix npm install crash (#260)

### DIFF
--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -13,12 +13,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3.0.2
+            - uses: actions/checkout@v7
 
             - name: Set up Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v7
               with:
-                node-version: 22
+                node-version: 24
 
             - name: Install package
               run: npm install --save ./api/
@@ -36,12 +36,12 @@ jobs:
                 working-directory: api
 
         steps:
-            - uses: actions/checkout@v3.0.2
+            - uses: actions/checkout@v7
 
             - name: Set up Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v7
               with:
-                node-version: 22
+                node-version: 24
 
             - name: Install dependencies
               run: npm install
@@ -56,12 +56,12 @@ jobs:
                 working-directory: client
 
         steps:
-            - uses: actions/checkout@v3.0.2
+            - uses: actions/checkout@v7
 
             - name: Set up Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v7
               with:
-                node-version: 22
+                node-version: 24
 
             - name: Install dependencies
               run: npm install

--- a/AGENT.md
+++ b/AGENT.md
@@ -43,7 +43,7 @@
   - API: `cd api`
   - Client: `cd client`
   - MCP server: `cd mcp`
-- Local Node development should follow `.nvmrc` (`v20.11.0`). The GitHub Actions workflow currently runs Node 22.
+- Local Node development should follow `.nvmrc` (`v20.11.0`). The GitHub Actions workflow currently runs Node 24.
 - Before running the stack locally, copy `.env.sample` to `.env` and fill in the required variables. Empty placeholder `VITE_*` entries may be needed for some Docker commands.
 
 ### Full stack


### PR DESCRIPTION
Fixes #260.

## What broke

vitest 5.0.0 was published and tagged `latest` on 2026-09-03 at 12:24 UTC. The first failing run started at 14:37 UTC. Nothing in this repo changed.

The api pins `vitest@^4.1.0`, which resolves to 4.1.11. Its peer chain is vitest -> vite 8.2.2 -> `@vitejs/devtools` (optional) -> `@vitejs/devtools-vitest` (optional), and that last package has a peer on `vitest@*`. npm resolves a bare `*` to the `latest` tag. Until 2026-09-03 that was 4.1.11, the same version already in the tree, so the walk stopped. Now it is 5.0.0, and npm 10 (bundled with Node 22) crashes trying to place a second vitest inside a virtual root with no parent:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

Same class of bug as npm/cli#9787. Reproduced locally under Node 22.23.2 and npm 10.9.8 (the runner's exact npm). The same install with `--before=2026-08-27T17:00:00Z` passes and yields the same 307 packages the Aug 27 run installed.

## Fix

Run CI on Node 24, which bundles npm 11.19. npm 11 and 12 both resolve this cycle. Also bump `actions/checkout` and `actions/setup-node` to v7, which clears the Node 20 deprecation warnings on every run. `AGENT.md` updated to match.

## Verified locally under Node 24.20.0 / npm 11.19.0

- api `npm install`: passes, 307 packages
- root `npm install --save ./api/`, `npm ci`, `npx eslint .`: all pass
- client `npm install` and `vitest run --coverage`: pass, 93/93
- api `vitest run --coverage`: timed out on a shifting handful of route tests on my machine under both Node 22 and Node 24. This is local flakiness. The live run here is the real check.

## Not changed

- `.nvmrc` (v20.11.0) and the Dockerfiles (`node:20`, `node:22-alpine`) are untouched. This PR only moves CI.
- Lockfiles remain gitignored. Committing them and using `npm ci` would also have fixed this and would keep it from recurring at vitest 6. That is a separate policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkbdCb19xqmqdbQsNxDWh
